### PR TITLE
fix(docker): bump base image to python:3.14.4-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.14.3-slim AS base
+FROM python:3.14.4-slim AS base
 
 ENV PYTHONUNBUFFERED=1 \
         PYTHONDONTWRITEBYTECODE=1 \


### PR DESCRIPTION
## Backgrounds

Atlas クラスタ上の Argo Rollout (`streamshuttle` namespace) が新リビジョンで CrashLoopBackOff・Degraded に陥っていた。Pod のログには以下が出ていた。

```
/app/entrypoint.sh: /app/.venv/bin/uvicorn: /app/.venv/bin/python: bad interpreter: Permission denied
/app/entrypoint.sh: line 7: /app/.venv/bin/uvicorn: Success
```

Renovate コミット `414d3c1` が `pyproject.toml` の `requires-python` を `>=3.14.3` → `>=3.14.4` に引き上げた一方、`Dockerfile:3` の base image は `python:3.14.3-slim` のままだった。このため builder ステージで uv が制約を満たせず `python-build-standalone` の Python 3.14.4 を `/root/.local/share/uv/python/cpython-3.14.4-...-linux-gnu/` にダウンロードし、production ステージはこれを `/home/appuser/.local/share/uv` にコピー、`Dockerfile:73-80` のループで `/app/.venv/bin/python*` の symlink ターゲットを書き換えていた。`Dockerfile:72` の `find -type f -exec chmod +x` は symlink 追跡先まで届かないため、appuser から Python バイナリを exec できず `bad interpreter: Permission denied` で Pod が起動しなかった。

## Goals

- `Dockerfile:3` の base image を `python:3.14.4-slim` に上げ、`requires-python` と整合させる。
- `python-build-standalone` 経由の Python 配置経路を排除し、production ステージの symlink + chmod ロジックに依存しなくても appuser が Python を実行できる状態に戻す。
- Atlas Rollout の CrashLoopBackOff を解消する。

## NonGoals

- `Dockerfile:71-80` の chmod / symlink ロジックの再設計（別タスクへ）。
- 親リポジトリの未コミット差分の修正（本件と無関係）。
- Atlas クラスタへの kubectl 操作（人間判断のため Worker は実行しない）。

## Checks

- [x] CLAUDE.md および `.claude/na2na-rules/agent-framework.md` を確認した
- [x] 実装前に `mcp__modifius__defect-analysis`, `mcp__modifius__defect-score-summary`, `mcp__modifius__defect-suggestImprovement` を実行した（欠陥スコア 0）
- [x] Dockerfile の差分は line 3 の 1 行のみ
- [x] `.editorconfig` 準拠（LF 改行、最終改行あり、行末空白なし、インデント維持）
- [x] `docker build --target=production -t streamshuttle-test:atlas-fix .` 成功
- [x] `docker run --rm --entrypoint="" streamshuttle-test:atlas-fix /app/.venv/bin/python --version` で `Python 3.14.4` が表示され EACCES なし
- [x] `ruff check .` 成功
- [x] `ruff format --check .` 成功
- [x] `pytest tests/unit/ -q` リグレッションなく成功（386 passed）
- [x] Conventional Commits でコミット
- [x] ブランチ `docker/atlas-rollout-fix/python-base-bump` を origin に push
- [x] PR 作成

## Test Results

<details>
<summary>Unit Tests</summary>

```sh
$ .venv/bin/pytest tests/unit/ -q
........................................................................ [ 18%]
........................................................................ [ 37%]
........................................................................ [ 55%]
........................................................................ [ 74%]
........................................................................ [ 93%]
..........................                                               [100%]
=============================== warnings summary ===============================
.venv/lib/python3.14/site-packages/slowapi/extension.py:717
.venv/lib/python3.14/site-packages/slowapi/extension.py:717
.venv/lib/python3.14/site-packages/slowapi/extension.py:717
  /Users/na2na/repos/na2na-p/StreamShuttle/.worktrees/atlas-rollout-fix/.venv/lib/python3.14/site-packages/slowapi/extension.py:717: DeprecationWarning: 'asyncio.iscoroutinefunction' is deprecated and slated for removal in Python 3.16; use inspect.iscoroutinefunction() instead
    if asyncio.iscoroutinefunction(func):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
386 passed, 3 warnings in 1.72s
```

</details>

<details>
<summary>Docker Build (production target)</summary>

```sh
$ docker build --target=production -t streamshuttle-test:atlas-fix .
... (省略) ...
#22 [production 5/5] RUN chmod +x entrypoint.sh && find /app/.venv/bin -type f -exec chmod +x {} ; && for link in /app/.venv/bin/python*; do ...
#22 DONE 0.1s

#23 exporting to image
#23 writing image sha256:09a2e1657df76b85b1fd2651f4432c6134e26d4169de329d724c95b210a24c26 done
#23 naming to docker.io/library/streamshuttle-test:atlas-fix done
#23 DONE 1.4s
```

</details>

<details>
<summary>Docker Run (Python interpreter check as appuser)</summary>

```sh
$ docker run --rm --entrypoint="" streamshuttle-test:atlas-fix /app/.venv/bin/python --version
Python 3.14.4

$ docker run --rm --entrypoint="" streamshuttle-test:atlas-fix sh -c 'whoami && /app/.venv/bin/uvicorn --version && ls -la /app/.venv/bin/python /app/.venv/bin/python3 /app/.venv/bin/python3.14'
appuser
Running uvicorn 0.44.0 with CPython 3.14.4 on Linux
lrwxrwxrwx 1 root root 22 May  1 03:23 /app/.venv/bin/python -> /usr/local/bin/python3
lrwxrwxrwx 1 root root  6 May  1 03:23 /app/.venv/bin/python3 -> python
lrwxrwxrwx 1 root root  6 May  1 03:23 /app/.venv/bin/python3.14 -> python
```

`/app/.venv/bin/python` が base image の `/usr/local/bin/python3` (= python:3.14.4-slim) に解決されており、`python-build-standalone` 経由の経路が消えていることを確認。`bad interpreter: Permission denied` は再現しない。

</details>

## Linter Results

<details>
<summary>Ruff Check</summary>

```sh
$ .venv/bin/ruff check .
All checks passed!
```

</details>

<details>
<summary>Ruff Format</summary>

```sh
$ .venv/bin/ruff format --check .
161 files already formatted
```

</details>

## Pre-Implementation Defect Analysis (modifius)

- `mcp__modifius__defect-analysis`: 関心の分離欠陥 0 件、カプセル化欠陥 0 件。Dockerfile 1 行の base image バージョン整合性修正であり、ドメイン設計欠陥には該当しない。
- `mcp__modifius__defect-score-summary`: 総欠陥行数 0、総欠陥スコア 0。
- `mcp__modifius__defect-suggestImprovement`: 検出された欠陥がないため改善提案は該当なし。

## Concerns / Notes

- 本 PR は Atlas Pod の起動復旧を最小差分で実現するためのもの。`Dockerfile:71-80` の symlink/chmod ロジックは standalone Python 経路に対して脆弱な設計が残ったままであり、別タスクで再設計したい（将来 base image と `requires-python` が再びズレた場合に同じ事故が再発するため）。
- 本 PR マージ後、Atlas 側で Argo Rollout の abort / promote または再ロールアウトを人間判断で実施する必要がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)