### PR TITLE
chore(renovate): sync python version updates between pyproject and dockerfile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,12 @@
       "groupName": "dev dependencies",
       "matchDepTypes": ["dev"],
       "matchManagers": ["pep621"]
+    },
+    {
+      "groupName": "python version",
+      "groupSlug": "python-version",
+      "matchPackageNames": ["python"],
+      "matchManagers": ["dockerfile", "pep621"]
     }
   ],
   "rangeStrategy": "bump",


### PR DESCRIPTION
## Backgrounds

直近 Atlas クラスタ上の StreamShuttle が `bad interpreter: Permission denied` で CrashLoopBackOff に陥った。原因は Renovate が `pyproject.toml` の `requires-python` を `>=3.14.3` から `>=3.14.4` に上げた一方、`Dockerfile:3` の base image が `python:3.14.3-slim` のまま取り残されたバージョン不整合。

PR #162 で Dockerfile の base image を `python:3.14.4-slim` に揃えて応急対応済みだが、Renovate 設定上は両者が **別 PR で別タイミングにマージされうる** 構造のままであり、構造的に同じ事故が再発しうる。

調査の結果、Renovate の以下挙動を確認:

- pep621 manager は `requires-python` を `packageName: "python"` / `datasource: "python-version"` / `versioning: "pep440"` として既に抽出している（[公式ドキュメント](https://docs.renovatebot.com/modules/manager/pep621/)）
- dockerfile manager は `FROM python:X.Y.Z-slim` を `depName: "python"` / `datasource: "docker"` として抽出している
- 両者は `packageName/depName` が同じ `"python"` のため、`matchPackageNames: ["python"]` 一発で横断マッチできる

したがって `customManagers` 等の追加は不要で、`packageRules` に horizontal な group ルールを 1 つ加えれば PR を 1 本にまとめられる。

## Goals

- `requires-python` (pep621) と Dockerfile `FROM python:` (dockerfile) の更新を **必ず同一 PR** にまとめる
- 既存の production / dev 依存グルーピングには影響を与えない
- 最小差分（`renovate.json` のみ、6 行追加）で実現

## NonGoals

- 既存 packageRules の意図変更
- Atlas クラスタへの kubectl 操作
- Dockerfile / pyproject.toml の編集

## 採用したアプローチ

`packageRules` に以下の 1 ブロックを追加:

```json
{
  "groupName": "python version",
  "groupSlug": "python-version",
  "matchPackageNames": ["python"],
  "matchManagers": ["dockerfile", "pep621"]
}
```

- `matchPackageNames: ["python"]`: 両 manager が同じ packageName `"python"` を使うため、これだけで両者にマッチ
- `matchManagers: ["dockerfile", "pep621"]`: スコープを Python バージョン関連のみに限定し、他 manager の Python 名衝突を予防（防御的）
- `groupName` / `groupSlug`: branch / PR を `python-version` 単一に集約

タスクで提示された B/C パターン（`customManagers` 追加）は、`pep621` が既に `requires-python` を抽出しているため不要と判断。最小差分・最大堅牢の A パターンを採用。

## Test Results

JSON 構文 / Renovate 設定スキーマ双方で検証済み。Python 単体テストは本変更では走らない（プロダクションコード非変更）ため省略。

<details>
<summary>JSON syntax check (jq)</summary>

```sh
$ jq . renovate.json > /dev/null && echo "JSON syntax OK"
JSON syntax OK
```

</details>

<details>
<summary>Renovate config validator</summary>

```sh
$ npx --yes -p renovate -c "renovate-config-validator renovate.json"
 INFO: Validating renovate.json as global config
 INFO: Config validated successfully
```

</details>

<details>
<summary>EditorConfig compliance</summary>

```sh
$ tail -c 1 renovate.json | xxd
00000000: 0a                                       .

$ grep -n ' $' renovate.json
(no output: no trailing whitespace)
```

- 2 space インデント, LF 改行, 最終改行あり, 行末空白なし: いずれも `.editorconfig` 準拠

</details>

## Linter Results

本変更は `renovate.json` のみで Python コードに変更がないため `ruff` は対象外。