### PR TITLE
chore(renovate): bump python atomically across managers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,7 +25,8 @@
       "groupName": "python version",
       "groupSlug": "python-version",
       "matchPackageNames": ["python"],
-      "matchManagers": ["dockerfile", "pep621"]
+      "matchManagers": ["dockerfile", "pep621", "asdf"],
+      "minimumReleaseAge": "0 days"
     }
   ],
   "rangeStrategy": "bump",


### PR DESCRIPTION
## Backgrounds

Python のバージョンは3箇所で固定されている: `Dockerfile` の `FROM python:X-slim`、`pyproject.toml` の `requires-python`、`.tool-versions`(asdf)。

グローバルの `minimumReleaseAge: "14 days"` ゲートを、pep621(`requires-python`) と asdf(`.tool-versions`) の更新が先に通過してマージされる一方、Dockerfile のベースイメージタグだけ遅れて取り残されることがある。すると `FROM python:3.14.x-slim` が `requires-python` より古くなり、`uv sync` がシステム Python を使えず uv 管理 Python をダウンロード → その実体バイナリを appuser(UID 1000) が exec できず `bad interpreter: Permission denied` → Pod が CrashLoopBackOff。

この事象は **3.14.3→3.14.4**（commit `c5997cd`）に続き **3.14.4→3.14.5**（#173/#174 で pyproject だけ先行）でも再発した。既存の "python version" グループ(#163)だけでは skew を防げていない。

## Goals

- python 関連の3つのピン(Dockerfile/pyproject/.tool-versions)を **1つのPRで原子的に**更新し、skew による CrashLoop 再発を防ぐ。

## 変更内容

`renovate.json` の "python version" グループに:
- `asdf` マネージャーを追加（`.tool-versions` の python も同グループへ）
- `minimumReleaseAge: "0 days"` を上書き（python のみゲートを無効化し、3ピンが同時に eligible になり同一PRへ集約）

```diff
       "matchPackageNames": ["python"],
-      "matchManagers": ["dockerfile", "pep621"]
+      "matchManagers": ["dockerfile", "pep621", "asdf"],
+      "minimumReleaseAge": "0 days"
```

## NonGoals

- 今回の即時復旧（3.14.5-slim への bump）は Dependency Dashboard 経由で Renovate に別途出させている（本PRはスコープ外）。

## 補足（代替案）

より堅牢にするなら `requires-python` をパッチ固定せず `>=3.14` に緩める案もある（ベースイメージのパッチを唯一の真実とし、requires-python がベースを追い越せなくする）。今回はRenovateのアトミックなグループPR方式を採用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)