### PR TITLE
chore(ci): tune artifact retention and uploads

### DIFF
--- a/.github/workflows/app-ci.yml
+++ b/.github/workflows/app-ci.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           name: coverage-report
           path: htmlcov/
+          retention-days: 3
 
   docker-build:
     runs-on: ubuntu-latest
@@ -69,6 +70,8 @@ jobs:
 
       - name: Build Docker image
         uses: docker/build-push-action@v7
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: .
           push: false


### PR DESCRIPTION
## Background

GitHub Actions artifact storage is a **shared quota across the entire account** (private Free = 500MB). When this quota fills up, it blocks CI in unrelated repositories with `Failed to CreateArtifact: Artifact storage quota has been hit`.

This is the third stage of a three-stage remediation:

1. Delete accumulated unexpired artifacts (55.1MB → 0.95MB)
2. Change repository default artifact-and-log retention from 90 days → 14 days (all repos, via API)
3. **Fix workflows that explicitly set `retention-days` longer than the default** ← This PR

## Changes

Account-wide Actions artifact storage is a shared quota that
recently filled up and blocked CI in unrelated repositories.

- coverage-report had no retention-days and was falling back to the
  repository default; pin it explicitly to 3 days rather than rely
  on the default staying short.
- docker/build-push-action auto-uploads a *.dockerbuild build record
  artifact even without an explicit upload-artifact step; disable it
  since nothing consumes it.

## Notes

The `if: always()` condition is retained for the coverage report. Since the coverage report is a deliverable consumed on successful runs, it is not changed to `if: failure()`.
