### PR TITLE
feat(player): YouTube公開プレイリストの再生プレイヤーを追加

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ from slowapi.middleware import SlowAPIMiddleware
 
 from streamshuttle.di.container import get_redis_dao
 from streamshuttle.handler.download_handler import router as download_router
+from streamshuttle.handler.playlist_handler import router as playlist_router
 from streamshuttle.handler.resolve_handler import router as resolve_router
 from streamshuttle.shared.config import config
 from streamshuttle.shared.logging_config import setup_logging
@@ -87,6 +88,7 @@ templates = Jinja2Templates(directory="src/streamshuttle/templates")
 # ルーター登録
 app.include_router(resolve_router, tags=["Proxy API"])
 app.include_router(download_router, tags=["Download API"])
+app.include_router(playlist_router, tags=["Playlist API"])
 
 # 静的ファイル配信
 app.mount("/static", StaticFiles(directory="src/streamshuttle/static"), name="static")
@@ -108,6 +110,24 @@ async def index(request: Request):
         TemplateResponse: index.htmlテンプレートをレンダリングしたレスポンス
     """
     return templates.TemplateResponse("index.html", {"request": request})
+
+
+@app.get("/player")
+async def player(request: Request):
+    """
+    プレイリストプレイヤーのページを表示します
+
+    YouTubeの公開プレイリストURLを入力すると、含まれる動画を順番に再生できる
+    プレイヤーUIをレンダリングします。動画一覧の取得と再生URLの解決は、
+    クライアントから GET /playlist および GET /playlist/stream を呼び出して行います。
+
+    Args:
+        request: FastAPIのRequestオブジェクト（Jinja2テンプレートレンダリングに必要）
+
+    Returns:
+        TemplateResponse: player.htmlテンプレートをレンダリングしたレスポンス
+    """
+    return templates.TemplateResponse("player.html", {"request": request})
 
 
 @app.get("/healthz")

--- a/src/streamshuttle/di/container.py
+++ b/src/streamshuttle/di/container.py
@@ -11,6 +11,12 @@ from streamshuttle.infrastructure.external.youtube_resolver import YoutubeResolv
 from streamshuttle.infrastructure.query_service.format_url_query_service import (
     FormatUrlQueryService,
 )
+from streamshuttle.infrastructure.query_service.playlist_cache_query_service import (
+    PlaylistCacheQueryService,
+)
+from streamshuttle.infrastructure.query_service.playlist_query_service import (
+    PlaylistQueryService,
+)
 from streamshuttle.infrastructure.query_service.stream_url_query_service import (
     StreamUrlQueryService,
 )
@@ -19,6 +25,9 @@ from streamshuttle.infrastructure.query_service.video_format_query_service impor
 )
 from streamshuttle.infrastructure.query_service.video_formats_cache_query_service import (
     VideoFormatsCacheQueryService,
+)
+from streamshuttle.infrastructure.repository.playlist_repository import (
+    PlaylistRepository,
 )
 from streamshuttle.infrastructure.repository.redis_cache_repository import (
     RedisCacheRepository,
@@ -45,6 +54,7 @@ from streamshuttle.usecase.query.get_cached_format_url_usecase import (
 from streamshuttle.usecase.query.get_cached_stream_url_usecase import (
     GetCachedStreamUrlUseCase,
 )
+from streamshuttle.usecase.query.get_playlist_usecase import GetPlaylistUseCase
 from streamshuttle.usecase.query.get_video_formats_usecase import GetVideoFormatsUseCase
 
 # グローバルインスタンス（シングルトン）
@@ -149,6 +159,59 @@ def get_format_url_query_service() -> FormatUrlQueryService:
         FormatUrlQueryService: 初期化済みのQueryServiceインスタンス
     """
     return FormatUrlQueryService(redis_dao=get_redis_dao())
+
+
+def get_playlist_query_service() -> PlaylistQueryService:
+    """
+    PlaylistQueryServiceインスタンスを生成
+
+    取得件数の上限をセキュリティ設定から注入して生成します。
+
+    Returns:
+        PlaylistQueryService: 初期化済みのQueryServiceインスタンス
+    """
+    return PlaylistQueryService(max_items=config.security.max_playlist_items)
+
+
+def get_playlist_repository() -> PlaylistRepository:
+    """
+    PlaylistRepositoryインスタンスを生成
+
+    PlaylistRepositoryに必要なRedisDaoを注入して生成します。
+
+    Returns:
+        PlaylistRepository: 初期化済みのRepositoryインスタンス
+    """
+    return PlaylistRepository(redis_dao=get_redis_dao())
+
+
+def get_playlist_cache_query_service() -> PlaylistCacheQueryService:
+    """
+    PlaylistCacheQueryServiceインスタンスを生成
+
+    PlaylistCacheQueryServiceに必要なRedisDaoを注入して生成します。
+
+    Returns:
+        PlaylistCacheQueryService: 初期化済みのQueryServiceインスタンス
+    """
+    return PlaylistCacheQueryService(redis_dao=get_redis_dao())
+
+
+def get_playlist_use_case() -> GetPlaylistUseCase:
+    """
+    GetPlaylistUseCaseインスタンスを生成
+
+    必要な依存関係（yt-dlp QueryService、キャッシュRepository、キャッシュQueryService）
+    をすべて注入して生成します。
+
+    Returns:
+        GetPlaylistUseCase: 初期化済みのUseCaseインスタンス
+    """
+    return GetPlaylistUseCase(
+        query_service=get_playlist_query_service(),
+        repository=get_playlist_repository(),
+        cache_query_service=get_playlist_cache_query_service(),
+    )
 
 
 def get_youtube_resolver() -> YoutubeResolver:

--- a/src/streamshuttle/domain/model/cache_key/__init__.py
+++ b/src/streamshuttle/domain/model/cache_key/__init__.py
@@ -5,6 +5,7 @@ cache_key domain model package
 """
 
 from streamshuttle.domain.model.cache_key.format_url_cache_key import FormatUrlCacheKey
+from streamshuttle.domain.model.cache_key.playlist_cache_key import PlaylistCacheKey
 from streamshuttle.domain.model.cache_key.stream_url_cache_key import StreamUrlCacheKey
 
-__all__ = ["StreamUrlCacheKey", "FormatUrlCacheKey"]
+__all__ = ["StreamUrlCacheKey", "FormatUrlCacheKey", "PlaylistCacheKey"]

--- a/src/streamshuttle/domain/model/cache_key/playlist_cache_key.py
+++ b/src/streamshuttle/domain/model/cache_key/playlist_cache_key.py
@@ -1,0 +1,40 @@
+"""
+PlaylistCacheKey ValueObjectモジュール
+
+プレイリスト情報のキャッシュキーを表現するValueObjectを定義します。
+"""
+
+from dataclasses import dataclass
+
+from streamshuttle.domain.model.youtube_playlist.youtube_playlist_id import (
+    YouTubePlaylistId,
+)
+
+
+@dataclass(frozen=True)
+class PlaylistCacheKey:
+    """
+    プレイリスト情報のキャッシュキーを表現するValueObject
+
+    YouTubePlaylistIdから一意なキャッシュキーを生成します。
+    このValueObjectは不変であり、キャッシュキー形式の一貫性を保証します。
+
+    Attributes:
+        _playlist_id: YouTubeプレイリストID
+    """
+
+    _playlist_id: YouTubePlaylistId
+
+    @property
+    def value(self) -> str:
+        """
+        キャッシュキー文字列を返す
+
+        Returns:
+            str: 「playlist:playlist_id」形式のキャッシュキー
+        """
+        return f"playlist:{self._playlist_id.value}"
+
+    def __str__(self) -> str:
+        """キャッシュキーの文字列表現を返す"""
+        return self.value

--- a/src/streamshuttle/domain/model/youtube_playlist/__init__.py
+++ b/src/streamshuttle/domain/model/youtube_playlist/__init__.py
@@ -1,0 +1,16 @@
+"""YouTube プレイリストパッケージ
+
+YouTubeプレイリストに関するValueObjectをエクスポートします。
+"""
+
+from streamshuttle.domain.model.youtube_playlist.youtube_playlist_id import (
+    YouTubePlaylistId,
+)
+from streamshuttle.domain.model.youtube_playlist.youtube_playlist_url import (
+    YoutubePlaylistUrl,
+)
+
+__all__ = [
+    "YouTubePlaylistId",
+    "YoutubePlaylistUrl",
+]

--- a/src/streamshuttle/domain/model/youtube_playlist/youtube_playlist_id.py
+++ b/src/streamshuttle/domain/model/youtube_playlist/youtube_playlist_id.py
@@ -1,0 +1,81 @@
+"""
+YouTubePlaylistId ValueObjectモジュール
+
+YouTubeプレイリストIDを表現するValueObjectを定義します。
+"""
+
+import re
+from dataclasses import dataclass
+
+from streamshuttle.shared.exceptions import InvalidPlaylistIdError
+
+
+@dataclass(frozen=True)
+class YouTubePlaylistId:
+    """
+    YouTubeプレイリストIDを表現するValueObject
+
+    プレイリストIDは英数字・ハイフン・アンダースコアで構成され、
+    プレフィックスによって種別が異なります（PL: ユーザー作成、UU: チャンネルアップロード、
+    OLAK5uy_: 自動生成アルバム、RD: ミックス等）。
+    プレフィックスの種類は将来増減しうるため、文字種と長さのみを検証し、
+    本サービスが扱えない非公開プレイリスト（WL: 後で見る、LL: 高く評価した動画）のみ
+    明示的に拒否します。
+
+    このValueObjectは不変であり、生成時にプレイリストID形式の妥当性を検証します。
+
+    Attributes:
+        _value: YouTubeプレイリストID文字列（プライベートフィールド）
+    """
+
+    _value: str
+
+    MIN_LENGTH = 2
+    MAX_LENGTH = 64
+    # 認証が必要で公開プレイリストとして解決できないID
+    PRIVATE_PLAYLIST_IDS = ("WL", "LL")
+
+    @property
+    def value(self) -> str:
+        """
+        プレイリストIDの値を取得します
+
+        Returns:
+            str: YouTubeプレイリストID文字列
+        """
+        return self._value
+
+    def __post_init__(self) -> None:
+        """
+        インスタンス生成後のバリデーション
+
+        YouTubeプレイリストIDの形式を検証します。
+        - 空でないこと
+        - 2文字以上64文字以下であること
+        - 英数字、ハイフン、アンダースコアのみで構成されていること
+        - 非公開プレイリスト（WL、LL）でないこと
+
+        Raises:
+            InvalidPlaylistIdError: プレイリストIDの形式が不正な場合
+        """
+        if not self._value:
+            raise InvalidPlaylistIdError("プレイリストIDが空です")
+
+        if not self.MIN_LENGTH <= len(self._value) <= self.MAX_LENGTH:
+            raise InvalidPlaylistIdError(
+                f"プレイリストIDは{self.MIN_LENGTH}文字以上{self.MAX_LENGTH}文字以下である"
+                f"必要があります: {self._value}"
+            )
+
+        if not re.match(r"^[a-zA-Z0-9_-]+$", self._value):
+            raise InvalidPlaylistIdError(f"プレイリストIDの形式が不正です: {self._value}")
+
+        if self._value in self.PRIVATE_PLAYLIST_IDS:
+            raise InvalidPlaylistIdError(
+                f"非公開プレイリストは再生できません: {self._value}。"
+                f"公開プレイリストのURLを指定してください。"
+            )
+
+    def __str__(self) -> str:
+        """プレイリストIDの文字列表現を返す"""
+        return self._value

--- a/src/streamshuttle/domain/model/youtube_playlist/youtube_playlist_url.py
+++ b/src/streamshuttle/domain/model/youtube_playlist/youtube_playlist_url.py
@@ -1,0 +1,97 @@
+"""YouTube プレイリストURL ValueObjectモジュール"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import parse_qs, urlparse
+
+from streamshuttle.domain.model.youtube_playlist.youtube_playlist_id import (
+    YouTubePlaylistId,
+)
+from streamshuttle.shared.exceptions import InvalidPlaylistIdError, InvalidUrlError
+
+
+@dataclass(frozen=True)
+class YoutubePlaylistUrl:
+    """YouTubeプレイリストURLを表すValueObject
+
+    プレイリストURLの検証と playlist_id の抽出機能を提供する。
+
+    対応する形式:
+        - https://www.youtube.com/playlist?list=PLxxxx
+        - https://www.youtube.com/watch?v=xxxxx&list=PLxxxx（再生中URLからの取り込み）
+        - https://youtu.be/xxxxx?list=PLxxxx
+
+    Attributes:
+        _value: プレイリストURL文字列（プライベートフィールド）
+    """
+
+    _value: str
+
+    ALLOWED_DOMAINS = (
+        "youtube.com",
+        "www.youtube.com",
+        "m.youtube.com",
+        "youtu.be",
+        "www.youtu.be",
+    )
+
+    def __post_init__(self) -> None:
+        """URLのバリデーション"""
+        if not self._value.startswith(("http://", "https://")):
+            raise InvalidUrlError(
+                f"Invalid URL scheme: {self._value}. Only HTTP/HTTPS are allowed."
+            )
+
+        parsed = urlparse(self._value)
+        if parsed.hostname not in self.ALLOWED_DOMAINS:
+            raise InvalidUrlError(
+                f"Invalid domain: {parsed.hostname}. "
+                f"Allowed domains: {', '.join(self.ALLOWED_DOMAINS)}"
+            )
+
+    @property
+    def value(self) -> str:
+        """プレイリストURLの値を取得します"""
+        return self._value
+
+    def extract_playlist_id(self) -> YouTubePlaylistId:
+        """URLからplaylist_idを抽出する
+
+        listクエリパラメータからプレイリストIDを抽出します。
+
+        Returns:
+            YouTubePlaylistId: 抽出されたプレイリストID
+
+        Raises:
+            InvalidPlaylistIdError: playlist_idが抽出できない、または不正な形式の場合
+        """
+        parsed = urlparse(self._value)
+        query_params = parse_qs(parsed.query)
+        playlist_id = query_params.get("list", [None])[0]
+
+        if not playlist_id:
+            raise InvalidPlaylistIdError(
+                f"Could not extract playlist ID from URL: {self._value}. "
+                f"URLに list パラメータが含まれている必要があります。"
+            )
+
+        return YouTubePlaylistId(_value=playlist_id)
+
+    def to_canonical_url(self) -> str:
+        """プレイリストIDのみを含む正規化済みURLを返す
+
+        watch URLに list パラメータが付いている場合でも、動画単体ではなく
+        プレイリスト全体を取得できる形式（/playlist?list=...）へ正規化します。
+
+        Returns:
+            str: https://www.youtube.com/playlist?list={playlist_id} 形式のURL
+
+        Raises:
+            InvalidPlaylistIdError: playlist_idが抽出できない、または不正な形式の場合
+        """
+        playlist_id = self.extract_playlist_id()
+        return f"https://www.youtube.com/playlist?list={playlist_id.value}"
+
+    def __str__(self) -> str:
+        return self._value

--- a/src/streamshuttle/handler/playlist_handler.py
+++ b/src/streamshuttle/handler/playlist_handler.py
@@ -1,0 +1,163 @@
+"""
+プレイリストHandlerモジュール
+
+Web UIのプレイヤー用エンドポイントを提供します。
+プレイリストの動画一覧取得と、再生対象動画のストリームURL解決の
+2つのエンドポイントを提供します。
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from streamshuttle.di.container import (
+    get_playlist_use_case,
+    get_resolve_youtube_url_use_case,
+)
+from streamshuttle.domain.model.stream_url.youtube_video_id import YouTubeVideoId
+from streamshuttle.domain.model.youtube_url import YoutubeUrl
+from streamshuttle.handler.response.playlist_response import PlaylistResponse
+from streamshuttle.handler.response.stream_url_response import StreamUrlResponse
+from streamshuttle.shared.config import config
+from streamshuttle.shared.exceptions import (
+    InvalidPlaylistIdError,
+    InvalidUrlError,
+    InvalidVideoIdError,
+    PlaylistNotFoundError,
+    YouTubeResolverError,
+)
+from streamshuttle.shared.rate_limiter import limiter
+from streamshuttle.shared.validators.url_validator import UrlValidator
+from streamshuttle.usecase.command.resolve_youtube_url_usecase import (
+    ResolveYoutubeUrlUseCase,
+)
+from streamshuttle.usecase.query.get_playlist_usecase import GetPlaylistUseCase
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+url_validator = UrlValidator(max_length=config.security.max_url_length)
+
+
+@router.get("/playlist")
+@limiter.limit(config.rate_limit.playlist)
+async def get_playlist(
+    request: Request,
+    url: str = Query(..., description="YouTube公開プレイリストURL"),
+    use_case: GetPlaylistUseCase = Depends(get_playlist_use_case),
+) -> PlaylistResponse:
+    """
+    YouTube公開プレイリストの動画一覧を取得します
+
+    プレイリストURL（listパラメータを含むURL）を受け取り、含まれる動画の
+    ID・タイトル・長さ・サムネイルの一覧を返します。
+    各動画のストリームURLはこの時点では解決せず、再生時に
+    GET /playlist/stream で個別に解決します。
+
+    非公開・削除済みの動画は再生できないため一覧から除外されます。
+    動画数が上限（SECURITY_MAX_PLAYLIST_ITEMS）を超える場合は切り捨てられ、
+    playlist_info.truncated が true になります。
+
+    レート制限: IPアドレスごとに5リクエスト/分
+
+    Args:
+        request: FastAPI Request（レート制限用）
+        url: YouTubeプレイリストURL（必須クエリパラメータ）
+        use_case: GetPlaylistUseCase（DIコンテナから注入）
+
+    Returns:
+        PlaylistResponse: プレイリスト情報と動画一覧
+
+    Raises:
+        HTTPException: 以下の場合にHTTPエラーを返します
+            - 400 Bad Request: URLまたはプレイリストIDが無効、または長さ制限を超過
+            - 404 Not Found: プレイリストが存在しない、非公開、
+              または再生可能な動画を含まない
+            - 429 Too Many Requests: レート制限を超過
+            - 502 Bad Gateway: YouTubeへのアクセス失敗
+            - 500 Internal Server Error: その他の予期しないエラー
+    """
+    try:
+        url_validator.validate_length(url)
+
+        playlist_info, items = await use_case.execute(url)
+
+        return PlaylistResponse(playlist_info=playlist_info, items=items)
+    except InvalidPlaylistIdError:
+        logger.warning(f"Invalid playlist ID: url={url}", exc_info=True)
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid playlist URL. The URL must contain a public playlist (list=...).",
+        )
+    except InvalidUrlError:
+        logger.warning(f"Invalid URL in get_playlist: url={url}", exc_info=True)
+        raise HTTPException(status_code=400, detail="Invalid URL format.")
+    except PlaylistNotFoundError:
+        logger.warning(f"Playlist not found: url={url}", exc_info=True)
+        raise HTTPException(
+            status_code=404,
+            detail="Playlist not found, is private, or contains no playable videos.",
+        )
+    except YouTubeResolverError:
+        logger.error(f"Failed to fetch playlist: url={url}", exc_info=True)
+        raise HTTPException(status_code=502, detail="Failed to fetch playlist from YouTube.")
+    except Exception:
+        logger.error(f"Unexpected error in get_playlist: url={url}", exc_info=True)
+        raise HTTPException(
+            status_code=500, detail="An internal error occurred. Please try again later."
+        )
+
+
+@router.get("/playlist/stream")
+@limiter.limit(config.rate_limit.playlist_stream)
+async def get_playlist_stream(
+    request: Request,
+    video_id: str = Query(..., description="YouTube動画ID（11文字）"),
+    use_case: ResolveYoutubeUrlUseCase = Depends(get_resolve_youtube_url_use_case),
+) -> StreamUrlResponse:
+    """
+    プレイヤーで再生する動画のストリームURLを解決します
+
+    GET /resolve と同じ解決結果を、リダイレクトではなくJSONで返します。
+    プレイヤーは取得したURLを<video>要素に直接設定するため、シーク時の
+    レンジリクエストが本サービスを経由せず、レート制限を消費しません。
+
+    解決済みURLはRedisにキャッシュされ、有効期限内は再解決されません。
+
+    レート制限: IPアドレスごとに30リクエスト/分
+
+    Args:
+        request: FastAPI Request（レート制限用）
+        video_id: YouTube動画ID（必須クエリパラメータ）
+        use_case: ResolveYoutubeUrlUseCase（DIコンテナから注入）
+
+    Returns:
+        StreamUrlResponse: 動画IDと解決済みストリームURL
+
+    Raises:
+        HTTPException: 以下の場合にHTTPエラーを返します
+            - 400 Bad Request: 動画IDが無効な形式
+            - 429 Too Many Requests: レート制限を超過
+            - 502 Bad Gateway: YouTubeへのアクセス失敗、URL解決失敗
+            - 500 Internal Server Error: その他の予期しないエラー
+    """
+    try:
+        validated_video_id = YouTubeVideoId(_value=video_id)
+        youtube_url = YoutubeUrl(_value=f"https://www.youtube.com/watch?v={validated_video_id}")
+
+        stream_url = await use_case.execute(youtube_url)
+
+        return StreamUrlResponse(video_id=validated_video_id.value, stream_url=stream_url)
+    except InvalidVideoIdError:
+        logger.warning(f"Invalid video ID in get_playlist_stream: video_id={video_id}")
+        raise HTTPException(status_code=400, detail="Invalid video ID format.")
+    except InvalidUrlError:
+        logger.warning(f"Invalid URL in get_playlist_stream: video_id={video_id}", exc_info=True)
+        raise HTTPException(status_code=400, detail="Invalid URL format.")
+    except YouTubeResolverError:
+        logger.error(f"Failed to resolve URL: video_id={video_id}", exc_info=True)
+        raise HTTPException(status_code=502, detail="Failed to resolve URL.")
+    except Exception:
+        logger.error(f"Unexpected error in get_playlist_stream: video_id={video_id}", exc_info=True)
+        raise HTTPException(
+            status_code=500, detail="An internal error occurred. Please try again later."
+        )

--- a/src/streamshuttle/handler/response/playlist_response.py
+++ b/src/streamshuttle/handler/response/playlist_response.py
@@ -1,0 +1,27 @@
+"""
+プレイリストレスポンスモデル定義モジュール
+
+GET /playlist エンドポイントのレスポンス構造を定義します。
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from streamshuttle.usecase.dto.playlist_info_dto import PlaylistInfoDto
+from streamshuttle.usecase.dto.playlist_item_dto import PlaylistItemDto
+
+
+class PlaylistResponse(BaseModel):
+    """
+    プレイリストレスポンスモデル
+
+    YouTubeプレイリストの基本情報と再生可能な動画一覧を含むレスポンスを表現します。
+
+    Attributes:
+        playlist_info: プレイリストの基本情報
+        items: 再生可能な動画一覧
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    playlist_info: PlaylistInfoDto = Field(..., description="プレイリスト情報")
+    items: list[PlaylistItemDto] = Field(..., description="再生可能な動画一覧")

--- a/src/streamshuttle/handler/response/stream_url_response.py
+++ b/src/streamshuttle/handler/response/stream_url_response.py
@@ -1,0 +1,26 @@
+"""
+ストリームURLレスポンスモデル定義モジュール
+
+GET /playlist/stream エンドポイントのレスポンス構造を定義します。
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class StreamUrlResponse(BaseModel):
+    """
+    ストリームURLレスポンスモデル
+
+    プレイヤーが<video>要素に直接設定するための解決済みストリームURLを表現します。
+    リダイレクト（307）ではなくJSONで返すことで、シークのたびに解決処理へ
+    リクエストが飛ぶことを避けています。
+
+    Attributes:
+        video_id: YouTube動画ID
+        stream_url: 解決済みの直接ストリームURL
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    video_id: str = Field(..., description="YouTube動画ID")
+    stream_url: str = Field(..., description="解決済みの直接ストリームURL")

--- a/src/streamshuttle/infrastructure/external/ytdlp_options_factory.py
+++ b/src/streamshuttle/infrastructure/external/ytdlp_options_factory.py
@@ -57,6 +57,31 @@ class YtDlpOptionsFactory:
         return options
 
     @staticmethod
+    def create_playlist_extraction_options(playlist_end: int) -> dict:
+        """プレイリスト情報取得用オプションを生成
+
+        プレイリストに含まれる動画一覧をフラット抽出するためのオプション。
+        各動画のフォーマット解決は行わず、ID・タイトル・長さのみを取得するため、
+        大きなプレイリストでも高速に一覧を取得できる。
+
+        Args:
+            playlist_end: 取得を打ち切る位置（yt-dlpのplaylistendに対応）
+
+        Returns:
+            dict: yt-dlpオプション辞書
+        """
+        options = YtDlpOptionsFactory.create_base_options()
+        options.update(
+            {
+                "extract_flat": True,
+                "noplaylist": False,
+                "playlistend": playlist_end,
+                "skip_download": True,
+            }
+        )
+        return options
+
+    @staticmethod
     def create_url_resolution_options(format_spec: str, hls: bool = False) -> dict:
         """URL解決用オプションを生成
 

--- a/src/streamshuttle/infrastructure/query_service/playlist_cache_query_service.py
+++ b/src/streamshuttle/infrastructure/query_service/playlist_cache_query_service.py
@@ -1,0 +1,59 @@
+"""
+プレイリストキャッシュQueryService実装モジュール
+
+PlaylistCacheQueryService Protocolの実装クラスを定義します。
+"""
+
+from pydantic import ValidationError
+
+from streamshuttle.domain.model.cache_key.playlist_cache_key import PlaylistCacheKey
+from streamshuttle.domain.model.youtube_playlist import YouTubePlaylistId
+from streamshuttle.infrastructure.dao.redis_dao import RedisDao
+from streamshuttle.usecase.dto.playlist_dto import PlaylistDto
+
+
+class PlaylistCacheQueryService:
+    """
+    プレイリストキャッシュQueryService実装クラス
+
+    PlaylistCacheQueryService Protocolの実装です。
+    RedisDaoを使用してキャッシュからプレイリスト情報を取得します。
+
+    エラーハンドリング:
+        キャッシュ取得に失敗した場合やJSON破損時はNoneを返します。
+        これにより、キャッシュミスとして扱われ、通常のyt-dlp処理にフォールバックします。
+    """
+
+    def __init__(self, redis_dao: RedisDao) -> None:
+        """
+        PlaylistCacheQueryServiceを初期化します
+
+        Args:
+            redis_dao: Redis操作を行うDAOインスタンス
+        """
+        self._redis_dao = redis_dao
+
+    async def find_by_playlist_id(self, playlist_id: str) -> PlaylistDto | None:
+        """
+        プレイリストIDでプレイリスト情報を取得します
+
+        Args:
+            playlist_id: YouTubeプレイリストID
+
+        Returns:
+            PlaylistDto | None: キャッシュが存在する場合はPlaylistDto、
+                                存在しない場合やエラー時はNone
+        """
+        try:
+            cache_key = PlaylistCacheKey(_playlist_id=YouTubePlaylistId(_value=playlist_id))
+            cached_json = await self._redis_dao.get(key=cache_key.value)
+
+            if cached_json is None:
+                return None
+
+            return PlaylistDto.model_validate_json(cached_json)
+
+        except ValidationError:
+            return None
+        except Exception:
+            return None

--- a/src/streamshuttle/infrastructure/query_service/playlist_query_service.py
+++ b/src/streamshuttle/infrastructure/query_service/playlist_query_service.py
@@ -1,0 +1,207 @@
+"""
+プレイリスト QueryService実装モジュール
+
+UseCase層で定義されたPlaylistQueryServiceインターフェースの実装クラスを定義します。
+"""
+
+import asyncio
+
+import yt_dlp
+
+from streamshuttle.domain.model.youtube_playlist import YoutubePlaylistUrl
+from streamshuttle.infrastructure.external.ytdlp_options_factory import YtDlpOptionsFactory
+from streamshuttle.shared.exceptions import (
+    InvalidUrlError,
+    PlaylistNotFoundError,
+    YouTubeResolverError,
+)
+from streamshuttle.usecase.dto.playlist_info_dto import PlaylistInfoDto
+from streamshuttle.usecase.dto.playlist_item_dto import PlaylistItemDto
+
+# 再生できない項目（非公開・削除済み動画）のタイトルとしてyt-dlpが返す文字列
+UNAVAILABLE_TITLES = (
+    "[Private video]",
+    "[Deleted video]",
+    "[Unavailable video]",
+)
+
+# プレイリスト自体が利用できないことを示すyt-dlpのエラーメッセージ断片
+# （通信障害などのサービス側起因のエラーと区別し、404として扱うために使用する）
+PLAYLIST_UNAVAILABLE_MARKERS = (
+    "does not exist",
+    "is private",
+    "not found",
+    "no longer available",
+)
+
+
+class PlaylistQueryService:
+    """
+    プレイリスト QueryService実装クラス
+
+    PlaylistQueryServiceインターフェースのyt-dlp実装です。
+    yt-dlpのフラット抽出（extract_flat）を使用して、プレイリストに含まれる
+    動画のID・タイトル・長さのみを取得します。
+
+    実装の詳細:
+        - yt-dlpは同期処理のため、asyncio.to_threadで非同期化
+        - extract_flat=Trueで各動画のフォーマット解決を行わず高速に一覧取得
+        - 非公開・削除済みの動画は再生できないため一覧から除外
+        - プレイリストの不存在・非公開（404）と、通信障害等（502）を区別
+        - max_items件を超えるプレイリストは切り捨て（truncated=True）
+    """
+
+    def __init__(self, max_items: int) -> None:
+        """
+        PlaylistQueryServiceを初期化します
+
+        Args:
+            max_items: 取得する動画の最大件数（DoS対策の上限）
+        """
+        self._max_items = max_items
+
+    async def get_playlist(
+        self, playlist_url: str
+    ) -> tuple[PlaylistInfoDto, list[PlaylistItemDto]]:
+        """
+        プレイリストURLからプレイリスト情報と動画一覧を取得します
+
+        Args:
+            playlist_url: YouTubeプレイリストURL
+
+        Returns:
+            tuple[PlaylistInfoDto, list[PlaylistItemDto]]: プレイリスト情報と動画一覧
+
+        Raises:
+            InvalidUrlError: 無効なURLが指定された場合
+            PlaylistNotFoundError: プレイリストが存在しない、非公開、
+                または再生可能な動画を含まない場合
+            YouTubeResolverError: YouTubeへのアクセスに失敗した場合
+        """
+        try:
+            # URL検証はYoutubePlaylistUrl ValueObjectに委譲
+            validated_url = YoutubePlaylistUrl(_value=playlist_url)
+
+            # yt-dlpは同期処理のため、asyncio.to_threadで非同期化
+            info = await asyncio.to_thread(self._extract_info, validated_url.value)
+        except InvalidUrlError:
+            # URL検証エラーはそのまま再送出（クライアント側のエラー）
+            raise
+        except yt_dlp.utils.DownloadError as e:
+            # 存在しない・非公開のプレイリストはクライアント側の誤りとして扱い、
+            # 通信障害などサービス側起因のエラーと区別する
+            if self._is_playlist_unavailable(str(e)):
+                raise PlaylistNotFoundError(
+                    f"プレイリストが存在しないか、非公開です: {playlist_url}"
+                ) from e
+            raise YouTubeResolverError(
+                f"プレイリスト情報の取得に失敗しました: {playlist_url}"
+            ) from e
+        except Exception as e:
+            raise YouTubeResolverError(f"予期しないエラーが発生しました: {playlist_url}") from e
+
+        if info is None or not info.get("entries"):
+            raise PlaylistNotFoundError(
+                f"プレイリストが見つからないか、動画が含まれていません: {playlist_url}"
+            )
+
+        entries = list(info["entries"])
+        truncated = len(entries) > self._max_items
+        items = self._to_items(entries[: self._max_items])
+
+        if not items:
+            raise PlaylistNotFoundError(
+                f"再生可能な動画がプレイリストに含まれていません: {playlist_url}"
+            )
+
+        playlist_info = PlaylistInfoDto(
+            playlist_id=info.get("id", "unknown"),
+            title=info.get("title", "Unknown Playlist"),
+            uploader=info.get("uploader") or info.get("channel") or "",
+            item_count=len(items),
+            truncated=truncated,
+        )
+
+        return playlist_info, items
+
+    def _is_playlist_unavailable(self, error_message: str) -> bool:
+        """
+        yt-dlpのエラーメッセージがプレイリストの不存在・非公開を示すかを判定します
+
+        Args:
+            error_message: yt-dlpのエラーメッセージ
+
+        Returns:
+            bool: プレイリスト自体が利用できないことを示す場合True
+        """
+        lowered = error_message.lower()
+        return any(marker in lowered for marker in PLAYLIST_UNAVAILABLE_MARKERS)
+
+    def _to_items(self, entries: list) -> list[PlaylistItemDto]:
+        """
+        yt-dlpのエントリー一覧をPlaylistItemDtoのリストに変換します
+
+        再生できない項目（Noneエントリー、ID欠落、非公開・削除済み動画）は除外します。
+
+        Args:
+            entries: yt-dlpから取得したエントリーのリスト
+
+        Returns:
+            list[PlaylistItemDto]: 再生可能な動画のDTOリスト
+        """
+        items: list[PlaylistItemDto] = []
+
+        for entry in entries:
+            # 取得できなかったエントリーはNoneになることがある
+            if not entry:
+                continue
+
+            video_id = entry.get("id")
+            if not video_id:
+                continue
+
+            title = entry.get("title") or "Unknown Title"
+            if title in UNAVAILABLE_TITLES:
+                continue
+
+            duration = entry.get("duration")
+
+            items.append(
+                PlaylistItemDto(
+                    video_id=video_id,
+                    title=title,
+                    url=f"https://www.youtube.com/watch?v={video_id}",
+                    duration_seconds=int(duration) if duration else None,
+                    # サムネイルはCSPで許可済みのi.ytimg.comに正規化する
+                    thumbnail_url=f"https://i.ytimg.com/vi/{video_id}/mqdefault.jpg",
+                )
+            )
+
+        return items
+
+    def _extract_info(self, playlist_url: str) -> dict:
+        """
+        yt-dlpを使用してプレイリスト情報を抽出します（同期処理）
+
+        この内部メソッドはasyncio.to_threadから呼び出され、
+        yt-dlpの同期処理を実行します。
+
+        上限を超えたかどうかを判定するため、max_items + 1件まで取得します。
+
+        Args:
+            playlist_url: YouTubeプレイリストURL
+
+        Returns:
+            dict: yt-dlpから取得したプレイリスト情報辞書
+
+        Raises:
+            yt_dlp.utils.DownloadError: プレイリスト情報の取得に失敗した場合
+        """
+        ydl_opts = YtDlpOptionsFactory.create_playlist_extraction_options(
+            playlist_end=self._max_items + 1
+        )
+
+        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+            info = ydl.extract_info(playlist_url, download=False)
+
+        return info

--- a/src/streamshuttle/infrastructure/repository/playlist_repository.py
+++ b/src/streamshuttle/infrastructure/repository/playlist_repository.py
@@ -1,0 +1,60 @@
+"""
+プレイリストRepository実装モジュール
+
+PlaylistRepository Protocolの実装クラスを定義します。
+"""
+
+from streamshuttle.domain.model.cache_key.playlist_cache_key import PlaylistCacheKey
+from streamshuttle.domain.model.youtube_playlist import YouTubePlaylistId
+from streamshuttle.infrastructure.dao.redis_dao import RedisDao
+from streamshuttle.shared.config import config
+from streamshuttle.usecase.dto.playlist_dto import PlaylistDto
+
+
+class PlaylistRepository:
+    """
+    プレイリストRepository実装クラス
+
+    PlaylistRepository Protocolの実装です。
+    RedisDaoを使用してプレイリスト情報をキャッシュに保存します。
+
+    エラーハンドリング:
+        キャッシュ保存に失敗してもシステム全体のエラーにはせず、
+        処理を継続します（ベストエフォート）。
+    """
+
+    def __init__(self, redis_dao: RedisDao) -> None:
+        """
+        PlaylistRepositoryを初期化します
+
+        Args:
+            redis_dao: Redis操作を行うDAOインスタンス
+        """
+        self._redis_dao = redis_dao
+
+    async def save(self, playlist_id: str, playlist: PlaylistDto) -> None:
+        """
+        プレイリスト情報をキャッシュに保存します
+
+        PlaylistDtoをJSON形式でシリアライズし、Redisにキャッシュします。
+        TTLはconfig.cache.ttl_secondsで設定された値を使用します。
+
+        Args:
+            playlist_id: YouTubeプレイリストID
+            playlist: 保存するプレイリスト情報
+
+        Note:
+            キャッシュ保存に失敗した場合でも例外を投げません。
+            これにより、キャッシュ障害がサービス全体に影響しないようにします。
+        """
+        try:
+            cache_key = PlaylistCacheKey(_playlist_id=YouTubePlaylistId(_value=playlist_id))
+            json_data = playlist.model_dump_json()
+
+            await self._redis_dao.set(
+                key=cache_key.value,
+                value=json_data,
+                ttl=config.cache.ttl_seconds,
+            )
+        except Exception:
+            pass

--- a/src/streamshuttle/shared/config/rate_limit_config.py
+++ b/src/streamshuttle/shared/config/rate_limit_config.py
@@ -19,6 +19,18 @@ class RateLimitConfig(BaseSettings):
         default="5/minute",
         description="downloadエンドポイントのレート制限（デフォルト: 5リクエスト/分）",
     )
+    playlist: str = Field(
+        default="5/minute",
+        description="playlistエンドポイントのレート制限（デフォルト: 5リクエスト/分）",
+    )
+    playlist_stream: str = Field(
+        default="30/minute",
+        description="""playlist/streamエンドポイントのレート制限（デフォルト: 30リクエスト/分）
+
+        プレイリスト再生では曲送りのたびにURL解決が発生するため、
+        他のエンドポイントより緩い制限を設定しています。
+        """,
+    )
 
     model_config = {
         "env_prefix": "RATE_LIMIT_",

--- a/src/streamshuttle/shared/config/security_config.py
+++ b/src/streamshuttle/shared/config/security_config.py
@@ -26,6 +26,15 @@ class SecurityConfig(BaseSettings):
         - Log file bloat attacks
         """,
     )
+    max_playlist_items: int = Field(
+        default=200,
+        description="""Maximum number of playlist items to fetch (default: 200 items)
+
+        As a security measure for public usage, limits the number of videos fetched
+        from a single playlist. Prevents memory exhaustion and long-running yt-dlp
+        extraction caused by playlists containing thousands of videos.
+        """,
+    )
     csrf_secret_key: str = Field(
         description=(
             "Secret key for CSRF protection (environment variable: SECURITY_CSRF_SECRET_KEY)"

--- a/src/streamshuttle/shared/exceptions.py
+++ b/src/streamshuttle/shared/exceptions.py
@@ -79,6 +79,43 @@ class InvalidVideoIdError(StreamShuttleError):
         super().__init__(message)
 
 
+class InvalidPlaylistIdError(StreamShuttleError):
+    """
+    不正なプレイリストIDエラー例外クラス
+
+    YouTubeプレイリストIDが無効な形式、またはURLから抽出できない場合に発生する
+    エラーを表現します。非公開プレイリスト（後で見る、高く評価した動画）の指定も
+    このエラーとして扱います。
+    """
+
+    def __init__(self, message: str = "プレイリストIDが無効です") -> None:
+        """
+        不正なプレイリストIDエラーを初期化します
+
+        Args:
+            message: エラーメッセージ（デフォルト: "プレイリストIDが無効です"）
+        """
+        super().__init__(message)
+
+
+class PlaylistNotFoundError(StreamShuttleError):
+    """
+    プレイリスト取得失敗エラー例外クラス
+
+    プレイリストが存在しない、非公開である、または再生可能な動画を1件も
+    含まない場合に発生するエラーを表現します。
+    """
+
+    def __init__(self, message: str = "プレイリストが見つかりませんでした") -> None:
+        """
+        プレイリスト取得失敗エラーを初期化します
+
+        Args:
+            message: エラーメッセージ（デフォルト: "プレイリストが見つかりませんでした"）
+        """
+        super().__init__(message)
+
+
 class InvalidUrlError(StreamShuttleError):
     """
     不正なURL例外クラス

--- a/src/streamshuttle/shared/security_headers.py
+++ b/src/streamshuttle/shared/security_headers.py
@@ -42,6 +42,8 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
             "script-src 'self'; "
             "style-src 'self' 'unsafe-inline'; "  # Jinja2テンプレートのインラインスタイル許可
             "img-src 'self' data: https://i.ytimg.com; "  # YouTubeサムネイル画像を許可
+            # プレイヤーが再生する解決済みストリーム（Googleの動画配信ドメイン）を許可
+            "media-src 'self' https://*.googlevideo.com; "
             "connect-src 'self'; "
             "frame-ancestors 'none';"
         )

--- a/src/streamshuttle/static/css/style.css
+++ b/src/streamshuttle/static/css/style.css
@@ -36,7 +36,8 @@ main {
   padding: 0 1rem;
 }
 
-.download-section {
+.download-section,
+.player-section {
   background: white;
   padding: 2rem;
   border-radius: 8px;
@@ -297,7 +298,8 @@ button:disabled {
     margin: 1rem auto;
   }
 
-  .download-section {
+  .download-section,
+  .player-section {
     padding: 1.5rem;
   }
 
@@ -307,5 +309,148 @@ button:disabled {
 
   header h1 {
     font-size: 1.5rem;
+  }
+}
+
+/* グローバルナビゲーション */
+.global-nav {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  margin-top: 0.5rem;
+}
+
+.global-nav a {
+  color: #ecf0f1;
+  text-decoration: none;
+  font-size: 0.95rem;
+  padding-bottom: 2px;
+  border-bottom: 2px solid transparent;
+  transition: border-color 0.3s;
+}
+
+.global-nav a:hover {
+  border-bottom-color: #3498db;
+}
+
+/* お知らせメッセージ */
+.notice {
+  color: #7d6608;
+  padding: 1rem;
+  background-color: #fcf3cf;
+  border-radius: 4px;
+  margin: 1rem 0;
+}
+
+/* プレイヤー */
+.playlist-header {
+  margin-top: 2rem;
+}
+
+.playlist-header h2 {
+  font-size: 1.3rem;
+  color: #2c3e50;
+  word-wrap: break-word;
+}
+
+.playlist-meta {
+  font-size: 0.9rem;
+  color: #7f8c8d;
+}
+
+.video-player {
+  width: 100%;
+  margin-top: 1rem;
+  background-color: #000;
+  border-radius: 8px;
+  aspect-ratio: 16 / 9;
+}
+
+.now-playing {
+  margin-top: 0.75rem;
+  font-weight: 600;
+  color: #2c3e50;
+  word-wrap: break-word;
+}
+
+.player-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.player-controls .toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 400;
+  color: #555;
+  cursor: pointer;
+}
+
+/* プレイリスト一覧 */
+.playlist-items {
+  list-style: none;
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 420px;
+  overflow-y: auto;
+}
+
+.playlist-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem;
+  border: 2px solid #ddd;
+  border-radius: 4px;
+  background-color: white;
+  cursor: pointer;
+  transition: all 0.3s;
+}
+
+.playlist-item:hover {
+  border-color: #3498db;
+  background-color: #ecf0f1;
+}
+
+.playlist-item.playing {
+  border-color: #3498db;
+  background-color: #d6eaf8;
+}
+
+.playlist-item-thumbnail {
+  width: 120px;
+  height: 68px;
+  object-fit: cover;
+  border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.playlist-item-title {
+  flex: 1;
+  min-width: 0;
+  word-break: break-word;
+}
+
+.playlist-item-duration {
+  font-size: 0.9rem;
+  color: #7f8c8d;
+  font-family: monospace;
+  flex-shrink: 0;
+}
+
+@media (max-width: 600px) {
+  .playlist-item-thumbnail {
+    width: 80px;
+    height: 45px;
+  }
+
+  .playlist-item-title {
+    font-size: 0.9rem;
   }
 }

--- a/src/streamshuttle/static/js/player.js
+++ b/src/streamshuttle/static/js/player.js
@@ -1,0 +1,310 @@
+// YouTubeプレイリストプレイヤー
+// GET /playlist で取得した動画一覧を、GET /playlist/stream で解決した
+// ストリームURLを使って順番に再生する。
+document.addEventListener('DOMContentLoaded', function() {
+  // DOM要素の取得
+  const urlInput = document.getElementById('playlist-url-input');
+  const loadBtn = document.getElementById('load-playlist-btn');
+  const errorMessage = document.getElementById('player-error');
+  const noticeMessage = document.getElementById('player-notice');
+  const playerContainer = document.getElementById('player-container');
+  const playlistTitle = document.getElementById('playlist-title');
+  const playlistMeta = document.getElementById('playlist-meta');
+  const videoPlayer = document.getElementById('video-player');
+  const nowPlaying = document.getElementById('now-playing');
+  const prevBtn = document.getElementById('prev-btn');
+  const nextBtn = document.getElementById('next-btn');
+  const shuffleToggle = document.getElementById('shuffle-toggle');
+  const repeatToggle = document.getElementById('repeat-toggle');
+  const playlistItems = document.getElementById('playlist-items');
+
+  // 状態管理
+  let items = [];        // プレイリストの動画一覧
+  let playOrder = [];    // 再生順（itemsのインデックスの並び）
+  let orderPos = 0;      // playOrder内の現在位置
+  let failureCount = 0;  // 連続再生失敗数（全滅時の無限スキップ防止）
+  let loadToken = 0;     // 解決結果の到着順による表示ズレを防ぐトークン
+  let reportedErrorSrc = null;  // 失敗を通知済みのソース（同一動画の二重スキップ防止）
+
+  loadBtn.addEventListener('click', loadPlaylist);
+  prevBtn.addEventListener('click', () => step(-1));
+  nextBtn.addEventListener('click', () => step(1));
+  shuffleToggle.addEventListener('change', rebuildPlayOrder);
+  videoPlayer.addEventListener('ended', () => step(1));
+  videoPlayer.addEventListener('error', onPlaybackError);
+
+  // プレイリストを読み込む
+  async function loadPlaylist() {
+    const url = urlInput.value.trim();
+    if (!url) {
+      showError('プレイリストURLを入力してください');
+      return;
+    }
+
+    hideError();
+    hideNotice();
+    playerContainer.classList.add('hidden');
+    loadBtn.disabled = true;
+    loadBtn.textContent = '読み込み中...';
+
+    try {
+      const response = await fetch(`/playlist?url=${encodeURIComponent(url)}`);
+      const data = await parseResponse(response);
+
+      items = data.items;
+      playlistTitle.textContent = data.playlist_info.title;
+      playlistMeta.textContent = buildMetaText(data.playlist_info);
+
+      renderItems();
+      playerContainer.classList.remove('hidden');
+
+      if (data.playlist_info.truncated) {
+        showNotice(`動画が多いため、先頭 ${items.length} 件のみ読み込みました`);
+      }
+
+      playAt(0);
+    } catch (error) {
+      showError(`プレイリスト取得エラー: ${error.message}`);
+    } finally {
+      loadBtn.disabled = false;
+      loadBtn.textContent = 'プレイリスト読み込み';
+    }
+  }
+
+  // レスポンスをJSONとして解釈し、エラー時はサーバーのdetailを例外にする
+  async function parseResponse(response) {
+    let body = null;
+    try {
+      body = await response.json();
+    } catch (error) {
+      body = null;
+    }
+
+    if (!response.ok) {
+      const detail = body && body.detail ? body.detail : `HTTPエラー: ${response.status}`;
+      throw new Error(detail);
+    }
+
+    return body;
+  }
+
+  // プレイリスト情報の補足テキストを組み立てる
+  function buildMetaText(playlistInfo) {
+    const parts = [];
+    if (playlistInfo.uploader) {
+      parts.push(playlistInfo.uploader);
+    }
+    parts.push(`${playlistInfo.item_count} 件`);
+    return parts.join(' / ');
+  }
+
+  // 動画一覧を描画する
+  function renderItems() {
+    playlistItems.innerHTML = '';
+
+    items.forEach((item, index) => {
+      const listItem = document.createElement('li');
+      listItem.className = 'playlist-item';
+      listItem.dataset.index = String(index);
+
+      const thumbnail = document.createElement('img');
+      thumbnail.className = 'playlist-item-thumbnail';
+      thumbnail.src = item.thumbnail_url;
+      thumbnail.alt = '';
+      thumbnail.loading = 'lazy';
+
+      const title = document.createElement('span');
+      title.className = 'playlist-item-title';
+      title.textContent = item.title;
+
+      const duration = document.createElement('span');
+      duration.className = 'playlist-item-duration';
+      duration.textContent = formatDuration(item.duration_seconds);
+
+      listItem.appendChild(thumbnail);
+      listItem.appendChild(title);
+      listItem.appendChild(duration);
+      listItem.addEventListener('click', () => playAt(index));
+
+      playlistItems.appendChild(listItem);
+    });
+  }
+
+  // 秒数を mm:ss / h:mm:ss 形式に整形する
+  function formatDuration(seconds) {
+    if (!seconds) {
+      return '--:--';
+    }
+
+    const hours = Math.floor(seconds / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    const secs = Math.floor(seconds % 60);
+    const padded = (value) => String(value).padStart(2, '0');
+
+    return hours > 0
+      ? `${hours}:${padded(minutes)}:${padded(secs)}`
+      : `${minutes}:${padded(secs)}`;
+  }
+
+  // 指定インデックスの動画を再生する
+  async function playAt(index) {
+    if (index < 0 || index >= items.length) {
+      return;
+    }
+
+    buildPlayOrder(index);
+    await play(index);
+  }
+
+  // 再生順を（シャッフル設定に応じて）組み立て直す
+  function buildPlayOrder(currentIndex) {
+    const indices = items.map((_, index) => index);
+
+    if (shuffleToggle.checked) {
+      const rest = indices.filter((index) => index !== currentIndex);
+      shuffle(rest);
+      playOrder = [currentIndex, ...rest];
+      orderPos = 0;
+    } else {
+      playOrder = indices;
+      orderPos = currentIndex;
+    }
+  }
+
+  // シャッフル設定の変更時に、再生中の動画を保ったまま再生順を作り直す
+  function rebuildPlayOrder() {
+    if (items.length === 0) {
+      return;
+    }
+    buildPlayOrder(playOrder[orderPos] ?? 0);
+  }
+
+  // Fisher-Yatesシャッフル
+  function shuffle(array) {
+    for (let i = array.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [array[i], array[j]] = [array[j], array[i]];
+    }
+  }
+
+  // 再生位置を前後に移動する
+  function step(delta) {
+    if (items.length === 0) {
+      return;
+    }
+
+    const nextPos = orderPos + delta;
+
+    if (nextPos < 0 || nextPos >= playOrder.length) {
+      if (!repeatToggle.checked) {
+        nowPlaying.textContent = '再生を終了しました';
+        return;
+      }
+      orderPos = (nextPos + playOrder.length) % playOrder.length;
+    } else {
+      orderPos = nextPos;
+    }
+
+    play(playOrder[orderPos]);
+  }
+
+  // ストリームURLを解決して再生する
+  async function play(index) {
+    const item = items[index];
+    if (!item) {
+      return;
+    }
+
+    orderPos = Math.max(playOrder.indexOf(index), 0);
+    highlightCurrent(index);
+    hideError();
+    nowPlaying.textContent = `読み込み中: ${item.title}`;
+
+    const token = ++loadToken;
+
+    try {
+      const response = await fetch(`/playlist/stream?video_id=${encodeURIComponent(item.video_id)}`);
+      const data = await parseResponse(response);
+
+      // 解決中に別の動画へ切り替わっていた場合は、この結果を破棄する
+      if (token !== loadToken) {
+        return;
+      }
+
+      videoPlayer.src = data.stream_url;
+      await videoPlayer.play();
+
+      failureCount = 0;
+      nowPlaying.textContent = `再生中: ${item.title}`;
+    } catch (error) {
+      if (token !== loadToken) {
+        return;
+      }
+
+      // 自動再生がブラウザにブロックされただけの場合は、失敗として扱わない
+      if (error.name === 'NotAllowedError') {
+        nowPlaying.textContent = `再生準備完了: ${item.title}（再生ボタンを押してください）`;
+        return;
+      }
+
+      reportFailure(`再生できませんでした: ${item.title}（${error.message}）`);
+    }
+  }
+
+  // <video>要素側で発生した再生エラーを処理する
+  function onPlaybackError() {
+    if (!videoPlayer.src) {
+      return;
+    }
+
+    const item = items[playOrder[orderPos]];
+    reportFailure(`再生できませんでした: ${item ? item.title : '不明な動画'}`);
+  }
+
+  // 再生失敗を通知し、次の動画へスキップする（全動画が失敗した場合は停止）
+  //
+  // 読み込み失敗時はplay()のPromise棄却と<video>のerrorイベントの両方が発生しうるため、
+  // 同一ソースに対する2回目以降の通知は無視して二重スキップを防ぐ。
+  function reportFailure(message) {
+    if (reportedErrorSrc === videoPlayer.src) {
+      return;
+    }
+    reportedErrorSrc = videoPlayer.src;
+
+    showError(message);
+    failureCount += 1;
+
+    if (failureCount >= items.length) {
+      failureCount = 0;
+      nowPlaying.textContent = 'すべての動画を再生できませんでした';
+      return;
+    }
+
+    step(1);
+  }
+
+  // 再生中の項目を一覧上で強調する
+  function highlightCurrent(index) {
+    playlistItems.querySelectorAll('.playlist-item').forEach((element) => {
+      element.classList.toggle('playing', Number(element.dataset.index) === index);
+    });
+  }
+
+  function showError(message) {
+    errorMessage.textContent = message;
+    errorMessage.classList.remove('hidden');
+  }
+
+  function hideError() {
+    errorMessage.classList.add('hidden');
+  }
+
+  function showNotice(message) {
+    noticeMessage.textContent = message;
+    noticeMessage.classList.remove('hidden');
+  }
+
+  function hideNotice() {
+    noticeMessage.classList.add('hidden');
+  }
+});

--- a/src/streamshuttle/templates/base.html
+++ b/src/streamshuttle/templates/base.html
@@ -9,10 +9,14 @@
 <body>
   <header>
     <h1>StreamShuttle</h1>
+    <nav class="global-nav">
+      <a href="/">ダウンロード</a>
+      <a href="/player">プレイリスト再生</a>
+    </nav>
   </header>
   <main>
     {% block content %}{% endblock %}
   </main>
-  <script src="/static/js/app.js"></script>
+  {% block scripts %}<script src="/static/js/app.js"></script>{% endblock %}
 </body>
 </html>

--- a/src/streamshuttle/templates/index.html
+++ b/src/streamshuttle/templates/index.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block title %}動画ダウンロード - StreamShuttle{% endblock %}
+
 {% block content %}
 <section class="download-section">
   <form id="download-form">

--- a/src/streamshuttle/templates/player.html
+++ b/src/streamshuttle/templates/player.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+
+{% block title %}プレイリストプレイヤー - StreamShuttle{% endblock %}
+
+{% block content %}
+<section class="player-section">
+  <form id="playlist-form">
+    <label for="playlist-url-input">YouTube公開プレイリストURL:</label>
+    <input
+      type="url"
+      id="playlist-url-input"
+      name="url"
+      placeholder="https://www.youtube.com/playlist?list=..."
+      required
+    >
+    <button type="button" id="load-playlist-btn">プレイリスト読み込み</button>
+  </form>
+
+  <div id="player-error" class="error hidden"></div>
+  <div id="player-notice" class="notice hidden"></div>
+
+  <div id="player-container" class="hidden">
+    <div class="playlist-header">
+      <h2 id="playlist-title"></h2>
+      <p id="playlist-meta" class="playlist-meta"></p>
+    </div>
+
+    <video id="video-player" class="video-player" controls playsinline preload="metadata"></video>
+
+    <p id="now-playing" class="now-playing"></p>
+
+    <div class="player-controls">
+      <button type="button" id="prev-btn">前へ</button>
+      <button type="button" id="next-btn">次へ</button>
+      <label class="toggle">
+        <input type="checkbox" id="shuffle-toggle">
+        シャッフル
+      </label>
+      <label class="toggle">
+        <input type="checkbox" id="repeat-toggle" checked>
+        繰り返し
+      </label>
+    </div>
+
+    <ol id="playlist-items" class="playlist-items"></ol>
+  </div>
+</section>
+{% endblock %}
+
+{% block scripts %}<script src="/static/js/player.js"></script>{% endblock %}

--- a/src/streamshuttle/usecase/dto/playlist_dto.py
+++ b/src/streamshuttle/usecase/dto/playlist_dto.py
@@ -1,0 +1,28 @@
+"""
+プレイリスト統合 DTO定義モジュール
+
+プレイリスト情報と項目一覧を統合して保持するData Transfer Objectを定義します。
+"""
+
+from pydantic import BaseModel, ConfigDict
+
+from streamshuttle.usecase.dto.playlist_info_dto import PlaylistInfoDto
+from streamshuttle.usecase.dto.playlist_item_dto import PlaylistItemDto
+
+
+class PlaylistDto(BaseModel):
+    """
+    プレイリスト統合 DTO
+
+    プレイリスト情報と項目一覧を統合して保持します。
+    キャッシュのシリアライズ/デシリアライズに使用されます。
+
+    Attributes:
+        playlist_info: プレイリスト基本情報
+        items: プレイリストに含まれる動画一覧
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    playlist_info: PlaylistInfoDto
+    items: list[PlaylistItemDto]

--- a/src/streamshuttle/usecase/dto/playlist_info_dto.py
+++ b/src/streamshuttle/usecase/dto/playlist_info_dto.py
@@ -1,0 +1,31 @@
+"""
+プレイリスト情報 DTO定義モジュール
+
+QueryServiceから返されるプレイリストの基本情報を保持する
+Data Transfer Objectを定義します。
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PlaylistInfoDto(BaseModel):
+    """
+    プレイリスト情報 DTO
+
+    YouTubeプレイリストの基本情報を保持します。
+
+    Attributes:
+        playlist_id: プレイリストID
+        title: プレイリストタイトル
+        uploader: プレイリスト作成者名（取得できない場合は空文字）
+        item_count: 実際に取得できた再生可能な動画数
+        truncated: 上限件数により一部の動画が切り捨てられたか
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    playlist_id: str = Field(..., description="プレイリストID")
+    title: str = Field(..., description="プレイリストタイトル")
+    uploader: str = Field(..., description="プレイリスト作成者名")
+    item_count: int = Field(..., description="再生可能な動画数")
+    truncated: bool = Field(False, description="上限件数により切り捨てられたか")

--- a/src/streamshuttle/usecase/dto/playlist_item_dto.py
+++ b/src/streamshuttle/usecase/dto/playlist_item_dto.py
@@ -1,0 +1,33 @@
+"""
+プレイリスト項目 DTO定義モジュール
+
+QueryServiceから返されるプレイリスト内の動画1件分の情報を保持する
+Data Transfer Objectを定義します。
+"""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PlaylistItemDto(BaseModel):
+    """
+    プレイリスト項目 DTO
+
+    プレイリストに含まれる動画1件の基本情報を保持します。
+    プレイリスト取得はフラット抽出（各動画の詳細取得を行わない）のため、
+    ストリームURLは含まれません。再生時に別途解決されます。
+
+    Attributes:
+        video_id: YouTube動画ID
+        title: 動画タイトル
+        url: 動画の視聴URL（https://www.youtube.com/watch?v=xxxxx形式）
+        duration_seconds: 動画の長さ（秒）。取得できない場合はNone
+        thumbnail_url: サムネイルURL
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    video_id: str = Field(..., description="YouTube動画ID")
+    title: str = Field(..., description="動画タイトル")
+    url: str = Field(..., description="動画の視聴URL")
+    duration_seconds: int | None = Field(None, description="動画の長さ（秒）")
+    thumbnail_url: str = Field(..., description="サムネイルURL")

--- a/src/streamshuttle/usecase/query/get_playlist_usecase.py
+++ b/src/streamshuttle/usecase/query/get_playlist_usecase.py
@@ -1,0 +1,86 @@
+"""
+プレイリスト取得UseCaseモジュール
+
+YouTubeプレイリストの動画一覧を取得するUseCaseを定義します。
+"""
+
+from streamshuttle.domain.model.youtube_playlist import YoutubePlaylistUrl
+from streamshuttle.usecase.dto.playlist_dto import PlaylistDto
+from streamshuttle.usecase.dto.playlist_info_dto import PlaylistInfoDto
+from streamshuttle.usecase.dto.playlist_item_dto import PlaylistItemDto
+from streamshuttle.usecase.query_service.playlist_cache_query_service import (
+    PlaylistCacheQueryService,
+)
+from streamshuttle.usecase.query_service.playlist_query_service import PlaylistQueryService
+from streamshuttle.usecase.repository.playlist_repository import PlaylistRepository
+
+
+class GetPlaylistUseCase:
+    """
+    プレイリスト取得UseCase
+
+    YouTubeプレイリストURLから再生可能な動画一覧を取得します。
+    Redisキャッシュを活用し、2回目以降のリクエストを高速化します。
+    CQRS原則に準拠した参照専用のUseCaseです。
+    """
+
+    def __init__(
+        self,
+        query_service: PlaylistQueryService,
+        repository: PlaylistRepository,
+        cache_query_service: PlaylistCacheQueryService,
+    ) -> None:
+        """
+        GetPlaylistUseCaseを初期化します
+
+        Args:
+            query_service: プレイリスト参照用QueryService（yt-dlp呼び出し）
+            repository: プレイリストキャッシュ保存用Repository
+            cache_query_service: プレイリストキャッシュ取得用QueryService
+        """
+        self._query_service = query_service
+        self._repository = repository
+        self._cache_query_service = cache_query_service
+
+    async def execute(self, playlist_url: str) -> tuple[PlaylistInfoDto, list[PlaylistItemDto]]:
+        """
+        プレイリストURLから動画一覧とプレイリスト情報を取得します
+
+        1回目のリクエスト: yt-dlpで情報取得 → Redisにキャッシュ → 返却
+        2回目以降: Redisキャッシュから取得 → 返却
+
+        Args:
+            playlist_url: YouTubeプレイリストURL（listパラメータを含むURL）
+
+        Returns:
+            tuple[PlaylistInfoDto, list[PlaylistItemDto]]: プレイリスト情報と動画一覧
+
+        Raises:
+            InvalidUrlError: 無効なURLが指定された場合
+            InvalidPlaylistIdError: プレイリストIDが抽出できない、または不正な場合
+            PlaylistNotFoundError: プレイリストが存在しない、非公開、
+                または再生可能な動画を含まない場合
+            YouTubeResolverError: YouTubeへのアクセスに失敗した場合
+        """
+        # 1. URLを検証し、プレイリストIDを抽出
+        validated_url = YoutubePlaylistUrl(_value=playlist_url)
+        playlist_id = validated_url.extract_playlist_id().value
+
+        # 2. キャッシュチェック
+        cached_playlist = await self._cache_query_service.find_by_playlist_id(playlist_id)
+        if cached_playlist is not None:
+            return cached_playlist.playlist_info, cached_playlist.items
+
+        # 3. キャッシュミス: yt-dlpで取得
+        # watch URLにlistパラメータが付いている場合でもプレイリスト全体を取得するため、
+        # 正規化済みURL（/playlist?list=...）を使用する
+        playlist_info, items = await self._query_service.get_playlist(
+            validated_url.to_canonical_url()
+        )
+
+        # 4. キャッシュに保存
+        playlist_dto = PlaylistDto(playlist_info=playlist_info, items=items)
+        await self._repository.save(playlist_id=playlist_id, playlist=playlist_dto)
+
+        # 5. 結果を返す
+        return playlist_info, items

--- a/src/streamshuttle/usecase/query_service/playlist_cache_query_service.py
+++ b/src/streamshuttle/usecase/query_service/playlist_cache_query_service.py
@@ -1,0 +1,36 @@
+"""
+プレイリストキャッシュQueryService Protocolモジュール
+
+キャッシュからプレイリスト情報を取得するQueryServiceインターフェースを定義します。
+"""
+
+from typing import Protocol
+
+from streamshuttle.usecase.dto.playlist_dto import PlaylistDto
+
+
+class PlaylistCacheQueryService(Protocol):
+    """
+    プレイリストキャッシュQueryService Protocol
+
+    キャッシュからプレイリスト情報を取得するためのインターフェースです。
+    CQRS原則に従い、Query（読み取り）操作を担当します。
+
+    実装クラスはInfrastructure層に配置されます。
+    """
+
+    async def find_by_playlist_id(self, playlist_id: str) -> PlaylistDto | None:
+        """
+        プレイリストIDでプレイリスト情報を取得します
+
+        Args:
+            playlist_id: YouTubeプレイリストID
+
+        Returns:
+            PlaylistDto | None: キャッシュが存在する場合はPlaylistDto、存在しない場合はNone
+
+        Note:
+            キャッシュ取得に失敗した場合やJSON破損時は例外を投げず、Noneを返します。
+            これにより、キャッシュミスとして扱われ、通常のyt-dlp処理にフォールバックします。
+        """
+        ...

--- a/src/streamshuttle/usecase/query_service/playlist_query_service.py
+++ b/src/streamshuttle/usecase/query_service/playlist_query_service.py
@@ -1,0 +1,41 @@
+"""
+プレイリストQueryService Protocolモジュール
+
+YouTubeプレイリストの情報を取得するQueryServiceインターフェースを定義します。
+"""
+
+from typing import Protocol
+
+from streamshuttle.usecase.dto.playlist_info_dto import PlaylistInfoDto
+from streamshuttle.usecase.dto.playlist_item_dto import PlaylistItemDto
+
+
+class PlaylistQueryService(Protocol):
+    """
+    プレイリストQueryService Protocol
+
+    YouTubeプレイリストURLから、プレイリスト情報と含まれる動画一覧を取得するための
+    インターフェースです。CQRS原則に従い、Query（読み取り）操作を担当します。
+
+    実装クラスはInfrastructure層に配置されます。
+    """
+
+    async def get_playlist(
+        self, playlist_url: str
+    ) -> tuple[PlaylistInfoDto, list[PlaylistItemDto]]:
+        """
+        プレイリストURLからプレイリスト情報と動画一覧を取得します
+
+        Args:
+            playlist_url: YouTubeプレイリストURL
+
+        Returns:
+            tuple[PlaylistInfoDto, list[PlaylistItemDto]]: プレイリスト情報と動画一覧
+
+        Raises:
+            InvalidUrlError: 無効なURLが指定された場合
+            PlaylistNotFoundError: プレイリストが存在しない、非公開、
+                または再生可能な動画を含まない場合
+            YouTubeResolverError: YouTubeへのアクセスに失敗した場合
+        """
+        ...

--- a/src/streamshuttle/usecase/repository/playlist_repository.py
+++ b/src/streamshuttle/usecase/repository/playlist_repository.py
@@ -1,0 +1,33 @@
+"""
+プレイリストRepository Protocolモジュール
+
+プレイリスト情報のキャッシュ保存を行うRepositoryインターフェースを定義します。
+"""
+
+from typing import Protocol
+
+from streamshuttle.usecase.dto.playlist_dto import PlaylistDto
+
+
+class PlaylistRepository(Protocol):
+    """
+    プレイリストRepository Protocol
+
+    プレイリスト情報をキャッシュに保存するためのインターフェースです。
+    CQRS原則に従い、Command（書き込み）操作を担当します。
+
+    実装クラスはInfrastructure層に配置されます。
+    """
+
+    async def save(self, playlist_id: str, playlist: PlaylistDto) -> None:
+        """
+        プレイリスト情報をキャッシュに保存します
+
+        Args:
+            playlist_id: YouTubeプレイリストID
+            playlist: 保存するプレイリスト情報
+
+        Raises:
+            CacheException: キャッシュ操作に失敗した場合
+        """
+        ...

--- a/tests/integration/api/test_api_integration.py
+++ b/tests/integration/api/test_api_integration.py
@@ -216,3 +216,97 @@ def test_download_endpoint_with_real_youtube_url(client):
 
     # 307 Temporary Redirectまたはエラーが返されることを確認
     assert response.status_code in [307, 400, 502, 500]
+
+
+def test_player_page(client):
+    """
+    プレイヤーページ（GET /player）が正常に動作することを確認
+
+    プレイヤーUIのHTMLページが正しく返されることをテストします。
+
+    Args:
+        client: TestClientインスタンス
+    """
+    response = client.get("/player")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+
+    html_content = response.text
+    assert "<!DOCTYPE html>" in html_content
+    assert "playlist-url-input" in html_content
+    # プレイヤーページではプレイヤー用のスクリプトのみ読み込む
+    assert "/static/js/player.js" in html_content
+    assert "/static/js/app.js" not in html_content
+
+
+def test_player_page_allows_stream_media_in_csp(client):
+    """
+    プレイヤーが解決済みストリームを再生できるCSPが設定されていることを確認
+
+    Args:
+        client: TestClientインスタンス
+    """
+    response = client.get("/player")
+
+    csp = response.headers["content-security-policy"]
+    assert "media-src 'self' https://*.googlevideo.com" in csp
+
+
+def test_playlist_endpoint_requires_url_parameter(client):
+    """
+    /playlistエンドポイントがURLパラメータを要求することを確認
+
+    Args:
+        client: TestClientインスタンス
+    """
+    response = client.get("/playlist")
+    # urlパラメータがない場合は422エラー
+    assert response.status_code == 422
+
+
+def test_playlist_endpoint_with_invalid_url(client):
+    """
+    /playlistエンドポイントに不正なURLを渡した場合のエラーハンドリングを確認
+
+    Args:
+        client: TestClientインスタンス
+    """
+    response = client.get("/playlist?url=invalid_url")
+    # 不正なURLの場合は400 Bad Request
+    assert response.status_code == 400
+
+
+def test_playlist_endpoint_without_list_parameter(client):
+    """
+    /playlistエンドポイントにlistパラメータのないURLを渡した場合の動作を確認
+
+    Args:
+        client: TestClientインスタンス
+    """
+    response = client.get("/playlist?url=https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+    # プレイリストIDが抽出できない場合は400 Bad Request
+    assert response.status_code == 400
+
+
+def test_playlist_stream_endpoint_requires_video_id_parameter(client):
+    """
+    /playlist/streamエンドポイントがvideo_idパラメータを要求することを確認
+
+    Args:
+        client: TestClientインスタンス
+    """
+    response = client.get("/playlist/stream")
+    # video_idパラメータがない場合は422エラー
+    assert response.status_code == 422
+
+
+def test_playlist_stream_endpoint_with_invalid_video_id(client):
+    """
+    /playlist/streamエンドポイントに不正な動画IDを渡した場合のエラーハンドリングを確認
+
+    Args:
+        client: TestClientインスタンス
+    """
+    response = client.get("/playlist/stream?video_id=invalid")
+    # 動画ID形式が不正な場合は400 Bad Request
+    assert response.status_code == 400

--- a/tests/unit/domain/model/cache_key/test_playlist_cache_key.py
+++ b/tests/unit/domain/model/cache_key/test_playlist_cache_key.py
@@ -1,0 +1,47 @@
+"""
+PlaylistCacheKey ValueObject ユニットテスト
+
+プレイリストキャッシュキーの生成を検証します。
+"""
+
+from streamshuttle.domain.model.cache_key import PlaylistCacheKey
+from streamshuttle.domain.model.youtube_playlist import YouTubePlaylistId
+
+
+def test_playlist_cache_key_generates_prefixed_key():
+    """
+    正常系: プレイリストIDからキャッシュキーが生成されることを確認
+
+    Arrange: YouTubePlaylistIdを準備
+    Act: PlaylistCacheKeyを生成
+    Assert: 「playlist:プレイリストID」形式のキーが返される
+    """
+    # Arrange
+    playlist_id = YouTubePlaylistId(_value="PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf")
+
+    # Act
+    cache_key = PlaylistCacheKey(_playlist_id=playlist_id)
+
+    # Assert
+    assert cache_key.value == "playlist:PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf"
+    assert str(cache_key) == "playlist:PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf"
+
+
+def test_playlist_cache_key_differs_by_playlist_id():
+    """
+    正常系: プレイリストIDが異なればキャッシュキーも異なることを確認
+
+    Arrange: 異なる2つのプレイリストIDを準備
+    Act: それぞれPlaylistCacheKeyを生成
+    Assert: キーが一致しない
+    """
+    # Arrange
+    first = YouTubePlaylistId(_value="PLaaaaaaaaaaaa")
+    second = YouTubePlaylistId(_value="PLbbbbbbbbbbbb")
+
+    # Act
+    first_key = PlaylistCacheKey(_playlist_id=first)
+    second_key = PlaylistCacheKey(_playlist_id=second)
+
+    # Assert
+    assert first_key.value != second_key.value

--- a/tests/unit/domain/model/youtube_playlist/test_youtube_playlist_id.py
+++ b/tests/unit/domain/model/youtube_playlist/test_youtube_playlist_id.py
@@ -1,0 +1,80 @@
+"""
+YouTubePlaylistId ValueObject ユニットテスト
+
+プレイリストIDのバリデーションを検証します。
+"""
+
+import pytest
+
+from streamshuttle.domain.model.youtube_playlist import YouTubePlaylistId
+from streamshuttle.shared.exceptions import InvalidPlaylistIdError
+
+
+@pytest.mark.parametrize(
+    "playlist_id",
+    [
+        pytest.param("PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf", id="正常系: PL始まりのプレイリストID"),
+        pytest.param("UUrAXtmErZgOeiKm4sgNOknGv", id="正常系: チャンネルアップロード"),
+        pytest.param("OLAK5uy_kFVjPxbFOWnDJnRLXcAZL8_nSMHfLQqLo", id="正常系: 自動生成アルバム"),
+        pytest.param("RDdQw4w9WgXcQ", id="正常系: ミックス"),
+        pytest.param("PL-_abc123", id="正常系: ハイフンとアンダースコアを含む"),
+    ],
+)
+def test_youtube_playlist_id_accepts_valid_id(playlist_id):
+    """
+    正常系: 有効なプレイリストIDでValueObjectが生成できることを確認
+
+    Arrange: 有効なプレイリストIDを準備
+    Act: YouTubePlaylistIdを生成
+    Assert: valueが入力値と一致する
+    """
+    # Act
+    result = YouTubePlaylistId(_value=playlist_id)
+
+    # Assert
+    assert result.value == playlist_id
+    assert str(result) == playlist_id
+
+
+@pytest.mark.parametrize(
+    "playlist_id",
+    [
+        pytest.param("", id="異常系: 空文字"),
+        pytest.param("P", id="異常系: 1文字（短すぎる）"),
+        pytest.param("PL" + "a" * 63, id="異常系: 65文字（長すぎる）"),
+        pytest.param("PL!nvalid", id="異常系: 記号を含む"),
+        pytest.param("PL abc", id="異常系: 空白を含む"),
+        pytest.param("PL/../etc", id="異常系: パス区切りを含む"),
+    ],
+)
+def test_youtube_playlist_id_rejects_invalid_id(playlist_id):
+    """
+    異常系: 不正な形式のプレイリストIDが拒否されることを確認
+
+    Arrange: 不正な形式のプレイリストIDを準備
+    Act: YouTubePlaylistIdを生成
+    Assert: InvalidPlaylistIdErrorが送出される
+    """
+    # Act & Assert
+    with pytest.raises(InvalidPlaylistIdError):
+        YouTubePlaylistId(_value=playlist_id)
+
+
+@pytest.mark.parametrize(
+    "playlist_id",
+    [
+        pytest.param("WL", id="異常系: 後で見る（非公開）"),
+        pytest.param("LL", id="異常系: 高く評価した動画（非公開）"),
+    ],
+)
+def test_youtube_playlist_id_rejects_private_playlist(playlist_id):
+    """
+    異常系: 非公開プレイリストが拒否されることを確認
+
+    Arrange: 認証が必要な非公開プレイリストIDを準備
+    Act: YouTubePlaylistIdを生成
+    Assert: InvalidPlaylistIdErrorが送出される
+    """
+    # Act & Assert
+    with pytest.raises(InvalidPlaylistIdError):
+        YouTubePlaylistId(_value=playlist_id)

--- a/tests/unit/domain/model/youtube_playlist/test_youtube_playlist_url.py
+++ b/tests/unit/domain/model/youtube_playlist/test_youtube_playlist_url.py
@@ -1,0 +1,128 @@
+"""
+YoutubePlaylistUrl ValueObject ユニットテスト
+
+プレイリストURLのバリデーションとプレイリストID抽出を検証します。
+"""
+
+import pytest
+
+from streamshuttle.domain.model.youtube_playlist import YoutubePlaylistUrl
+from streamshuttle.shared.exceptions import InvalidPlaylistIdError, InvalidUrlError
+
+PLAYLIST_ID = "PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        pytest.param(
+            f"https://www.youtube.com/playlist?list={PLAYLIST_ID}",
+            id="正常系: playlist URL",
+        ),
+        pytest.param(
+            f"https://www.youtube.com/watch?v=dQw4w9WgXcQ&list={PLAYLIST_ID}",
+            id="正常系: watch URL（listパラメータ付き）",
+        ),
+        pytest.param(
+            f"https://youtu.be/dQw4w9WgXcQ?list={PLAYLIST_ID}",
+            id="正常系: 短縮URL（listパラメータ付き）",
+        ),
+        pytest.param(
+            f"https://m.youtube.com/playlist?list={PLAYLIST_ID}",
+            id="正常系: モバイルURL",
+        ),
+    ],
+)
+def test_youtube_playlist_url_extracts_playlist_id(url):
+    """
+    正常系: 各種URL形式からプレイリストIDが抽出できることを確認
+
+    Arrange: listパラメータを含むURLを準備
+    Act: extract_playlist_id()を呼び出す
+    Assert: プレイリストIDが抽出される
+    """
+    # Act
+    playlist_id = YoutubePlaylistUrl(_value=url).extract_playlist_id()
+
+    # Assert
+    assert playlist_id.value == PLAYLIST_ID
+
+
+def test_youtube_playlist_url_to_canonical_url_normalizes_watch_url():
+    """
+    正常系: watch URLがプレイリスト取得用URLに正規化されることを確認
+
+    Arrange: listパラメータ付きのwatch URLを準備
+    Act: to_canonical_url()を呼び出す
+    Assert: /playlist?list=形式のURLが返される
+    """
+    # Arrange
+    url = f"https://www.youtube.com/watch?v=dQw4w9WgXcQ&list={PLAYLIST_ID}"
+
+    # Act
+    canonical_url = YoutubePlaylistUrl(_value=url).to_canonical_url()
+
+    # Assert
+    assert canonical_url == f"https://www.youtube.com/playlist?list={PLAYLIST_ID}"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        pytest.param(
+            f"ftp://www.youtube.com/playlist?list={PLAYLIST_ID}",
+            id="異常系: 許可されないスキーム",
+        ),
+        pytest.param(
+            f"https://example.com/playlist?list={PLAYLIST_ID}",
+            id="異常系: 許可されないドメイン",
+        ),
+        pytest.param(
+            f"https://evil-youtube.com/playlist?list={PLAYLIST_ID}",
+            id="異常系: 類似ドメイン",
+        ),
+    ],
+)
+def test_youtube_playlist_url_rejects_invalid_url(url):
+    """
+    異常系: 不正なURLが拒否されることを確認
+
+    Arrange: スキームまたはドメインが不正なURLを準備
+    Act: YoutubePlaylistUrlを生成
+    Assert: InvalidUrlErrorが送出される
+    """
+    # Act & Assert
+    with pytest.raises(InvalidUrlError):
+        YoutubePlaylistUrl(_value=url)
+
+
+def test_youtube_playlist_url_rejects_url_without_list_parameter():
+    """
+    異常系: listパラメータを含まないURLが拒否されることを確認
+
+    Arrange: listパラメータのないwatch URLを準備
+    Act: extract_playlist_id()を呼び出す
+    Assert: InvalidPlaylistIdErrorが送出される
+    """
+    # Arrange
+    url = "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+    # Act & Assert
+    with pytest.raises(InvalidPlaylistIdError):
+        YoutubePlaylistUrl(_value=url).extract_playlist_id()
+
+
+def test_youtube_playlist_url_rejects_private_playlist_url():
+    """
+    異常系: 非公開プレイリストのURLが拒否されることを確認
+
+    Arrange: list=WL（後で見る）のURLを準備
+    Act: extract_playlist_id()を呼び出す
+    Assert: InvalidPlaylistIdErrorが送出される
+    """
+    # Arrange
+    url = "https://www.youtube.com/playlist?list=WL"
+
+    # Act & Assert
+    with pytest.raises(InvalidPlaylistIdError):
+        YoutubePlaylistUrl(_value=url).extract_playlist_id()

--- a/tests/unit/handler/test_playlist_handler.py
+++ b/tests/unit/handler/test_playlist_handler.py
@@ -1,0 +1,235 @@
+"""
+PlaylistHandler ユニットテスト
+
+PlaylistHandlerのエンドポイント動作を検証するユニットテストです。
+FastAPI TestClientを使用して、HTTPリクエスト/レスポンスの動作を検証します。
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from streamshuttle.di.container import (
+    get_playlist_use_case,
+    get_resolve_youtube_url_use_case,
+)
+from streamshuttle.handler.playlist_handler import router
+from streamshuttle.shared.exceptions import (
+    InvalidPlaylistIdError,
+    InvalidUrlError,
+    PlaylistNotFoundError,
+    YouTubeResolverError,
+)
+from streamshuttle.usecase.command.resolve_youtube_url_usecase import (
+    ResolveYoutubeUrlUseCase,
+)
+from streamshuttle.usecase.dto.playlist_info_dto import PlaylistInfoDto
+from streamshuttle.usecase.dto.playlist_item_dto import PlaylistItemDto
+from streamshuttle.usecase.query.get_playlist_usecase import GetPlaylistUseCase
+
+PLAYLIST_ID = "PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf"
+PLAYLIST_URL = f"https://www.youtube.com/playlist?list={PLAYLIST_ID}"
+
+
+@pytest.fixture
+def app():
+    """
+    テスト用FastAPIアプリケーションを作成します
+
+    Returns:
+        FastAPI: PlaylistHandlerのルーターを含むFastAPIアプリケーション
+    """
+    from streamshuttle.shared.rate_limiter import limiter
+
+    app = FastAPI()
+    app.state.limiter = limiter
+    app.include_router(router)
+    limiter.enabled = False
+    return app
+
+
+@pytest.fixture
+def mock_get_playlist_use_case():
+    """モックされたGetPlaylistUseCase"""
+    return AsyncMock(spec=GetPlaylistUseCase)
+
+
+@pytest.fixture
+def mock_resolve_use_case():
+    """モックされたResolveYoutubeUrlUseCase"""
+    return AsyncMock(spec=ResolveYoutubeUrlUseCase)
+
+
+@pytest.fixture
+def client(app, mock_get_playlist_use_case, mock_resolve_use_case):
+    """
+    テスト用クライアントを作成します
+
+    依存性オーバーライドを使用して、UseCaseをモックに置き換えます。
+
+    Returns:
+        TestClient: FastAPI TestClient
+    """
+    app.dependency_overrides[get_playlist_use_case] = lambda: mock_get_playlist_use_case
+    app.dependency_overrides[get_resolve_youtube_url_use_case] = lambda: mock_resolve_use_case
+    return TestClient(app)
+
+
+@pytest.fixture
+def playlist_result():
+    """UseCaseが返すプレイリスト情報と動画一覧"""
+    playlist_info = PlaylistInfoDto(
+        playlist_id=PLAYLIST_ID,
+        title="テストプレイリスト",
+        uploader="テストチャンネル",
+        item_count=2,
+        truncated=False,
+    )
+    items = [
+        PlaylistItemDto(
+            video_id="dQw4w9WgXcQ",
+            title="1曲目",
+            url="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            duration_seconds=120,
+            thumbnail_url="https://i.ytimg.com/vi/dQw4w9WgXcQ/mqdefault.jpg",
+        ),
+        PlaylistItemDto(
+            video_id="9bZkp7q19f0",
+            title="2曲目",
+            url="https://www.youtube.com/watch?v=9bZkp7q19f0",
+            duration_seconds=None,
+            thumbnail_url="https://i.ytimg.com/vi/9bZkp7q19f0/mqdefault.jpg",
+        ),
+    ]
+    return playlist_info, items
+
+
+def test_get_playlist_success(client, mock_get_playlist_use_case, playlist_result):
+    """
+    正常系: プレイリスト一覧の取得が成功し、JSON形式で返されることを検証します
+    """
+    # Arrange
+    mock_get_playlist_use_case.execute.return_value = playlist_result
+
+    # Act
+    response = client.get(f"/playlist?url={PLAYLIST_URL}")
+
+    # Assert
+    assert response.status_code == 200
+    json_data = response.json()
+    assert json_data["playlist_info"]["playlist_id"] == PLAYLIST_ID
+    assert json_data["playlist_info"]["title"] == "テストプレイリスト"
+    assert json_data["playlist_info"]["item_count"] == 2
+    assert json_data["playlist_info"]["truncated"] is False
+    assert len(json_data["items"]) == 2
+    assert json_data["items"][0]["video_id"] == "dQw4w9WgXcQ"
+    assert json_data["items"][1]["duration_seconds"] is None
+    mock_get_playlist_use_case.execute.assert_called_once_with(PLAYLIST_URL)
+
+
+def test_get_playlist_requires_url_parameter(client):
+    """
+    異常系: urlパラメータがない場合、422 Unprocessable Entityが返されることを検証します
+    """
+    # Act
+    response = client.get("/playlist")
+
+    # Assert
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize(
+    "error, expected_status",
+    [
+        pytest.param(InvalidPlaylistIdError(), 400, id="異常系: プレイリストID不正で400"),
+        pytest.param(InvalidUrlError(), 400, id="異常系: URL不正で400"),
+        pytest.param(PlaylistNotFoundError(), 404, id="異常系: プレイリスト未検出で404"),
+        pytest.param(YouTubeResolverError(), 502, id="異常系: YouTube接続失敗で502"),
+        pytest.param(Exception("unexpected"), 500, id="異常系: 予期しないエラーで500"),
+    ],
+)
+def test_get_playlist_error_responses(client, mock_get_playlist_use_case, error, expected_status):
+    """
+    異常系: UseCaseの例外が適切なHTTPステータスコードに変換されることを検証します
+    """
+    # Arrange
+    mock_get_playlist_use_case.execute.side_effect = error
+
+    # Act
+    response = client.get(f"/playlist?url={PLAYLIST_URL}")
+
+    # Assert
+    assert response.status_code == expected_status
+    assert "detail" in response.json()
+
+
+def test_get_playlist_rejects_too_long_url(client, mock_get_playlist_use_case):
+    """
+    異常系: 長さ制限を超えるURLが400 Bad Requestで拒否されることを検証します
+    """
+    # Arrange
+    long_url = f"{PLAYLIST_URL}{'a' * 3000}"
+
+    # Act
+    response = client.get("/playlist", params={"url": long_url})
+
+    # Assert
+    assert response.status_code == 400
+    mock_get_playlist_use_case.execute.assert_not_called()
+
+
+def test_get_playlist_stream_success(client, mock_resolve_use_case):
+    """
+    正常系: ストリームURLの解決が成功し、JSON形式で返されることを検証します
+    """
+    # Arrange
+    mock_resolve_use_case.execute.return_value = "https://example.googlevideo.com/videoplayback"
+
+    # Act
+    response = client.get("/playlist/stream?video_id=dQw4w9WgXcQ")
+
+    # Assert
+    assert response.status_code == 200
+    json_data = response.json()
+    assert json_data["video_id"] == "dQw4w9WgXcQ"
+    assert json_data["stream_url"] == "https://example.googlevideo.com/videoplayback"
+
+    # 動画IDから組み立てたYouTube URLでUseCaseが呼ばれることを確認
+    called_url = mock_resolve_use_case.execute.call_args.args[0]
+    assert called_url.value == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+
+
+def test_get_playlist_stream_rejects_invalid_video_id(client, mock_resolve_use_case):
+    """
+    異常系: 不正な形式の動画IDが400 Bad Requestで拒否されることを検証します
+    """
+    # Act
+    response = client.get("/playlist/stream?video_id=invalid")
+
+    # Assert
+    assert response.status_code == 400
+    mock_resolve_use_case.execute.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "error, expected_status",
+    [
+        pytest.param(YouTubeResolverError(), 502, id="異常系: URL解決失敗で502"),
+        pytest.param(Exception("unexpected"), 500, id="異常系: 予期しないエラーで500"),
+    ],
+)
+def test_get_playlist_stream_error_responses(client, mock_resolve_use_case, error, expected_status):
+    """
+    異常系: UseCaseの例外が適切なHTTPステータスコードに変換されることを検証します
+    """
+    # Arrange
+    mock_resolve_use_case.execute.side_effect = error
+
+    # Act
+    response = client.get("/playlist/stream?video_id=dQw4w9WgXcQ")
+
+    # Assert
+    assert response.status_code == expected_status
+    assert "detail" in response.json()

--- a/tests/unit/infrastructure/external/test_ytdlp_options_factory.py
+++ b/tests/unit/infrastructure/external/test_ytdlp_options_factory.py
@@ -216,3 +216,38 @@ class TestYtDlpOptionsFactory:
         # Assert
         assert key in options
         assert options[key] == expected_value
+
+    def test_create_playlist_extraction_options_inherits_base_options(self):
+        """プレイリスト取得オプションが基本オプションを継承することを確認"""
+        # Act
+        base_options = YtDlpOptionsFactory.create_base_options()
+        playlist_options = YtDlpOptionsFactory.create_playlist_extraction_options(playlist_end=201)
+
+        # Assert - 基本オプションのキーが全て含まれる
+        for key in base_options.keys():
+            assert key in playlist_options
+
+    @pytest.mark.parametrize(
+        "key, expected_value",
+        [
+            pytest.param("extract_flat", True, id="正常系: extract_flatがTrueである"),
+            pytest.param("noplaylist", False, id="正常系: noplaylistがFalseである"),
+            pytest.param("skip_download", True, id="正常系: skip_downloadがTrueである"),
+        ],
+    )
+    def test_create_playlist_extraction_options_has_specific_settings(self, key, expected_value):
+        """プレイリスト取得オプションに固有の設定が含まれることを確認"""
+        # Act
+        options = YtDlpOptionsFactory.create_playlist_extraction_options(playlist_end=201)
+
+        # Assert
+        assert key in options
+        assert options[key] == expected_value
+
+    def test_create_playlist_extraction_options_sets_playlist_end(self):
+        """プレイリスト取得オプションに取得上限が設定されることを確認"""
+        # Act
+        options = YtDlpOptionsFactory.create_playlist_extraction_options(playlist_end=42)
+
+        # Assert
+        assert options["playlistend"] == 42

--- a/tests/unit/infrastructure/query_service/test_playlist_cache_query_service.py
+++ b/tests/unit/infrastructure/query_service/test_playlist_cache_query_service.py
@@ -1,0 +1,95 @@
+"""PlaylistCacheQueryServiceのテストモジュール"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from streamshuttle.infrastructure.query_service.playlist_cache_query_service import (
+    PlaylistCacheQueryService,
+)
+from streamshuttle.usecase.dto.playlist_dto import PlaylistDto
+
+PLAYLIST_ID = "PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf"
+CACHED_JSON = (
+    '{"playlist_info":{"playlist_id":"PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf",'
+    '"title":"テストプレイリスト","uploader":"テストチャンネル","item_count":1,'
+    '"truncated":false},'
+    '"items":[{"video_id":"dQw4w9WgXcQ","title":"1曲目",'
+    '"url":"https://www.youtube.com/watch?v=dQw4w9WgXcQ","duration_seconds":120,'
+    '"thumbnail_url":"https://i.ytimg.com/vi/dQw4w9WgXcQ/mqdefault.jpg"}]}'
+)
+
+
+@pytest.fixture
+def mock_redis_dao():
+    """RedisDao のモックを提供するfixture"""
+    return AsyncMock()
+
+
+@pytest.fixture
+def query_service(mock_redis_dao):
+    """PlaylistCacheQueryService のインスタンスを提供するfixture"""
+    return PlaylistCacheQueryService(redis_dao=mock_redis_dao)
+
+
+async def test_find_by_playlist_id_returns_dto_on_cache_hit(query_service, mock_redis_dao):
+    """正常系: キャッシュヒット時にPlaylistDtoを返す"""
+    # Arrange
+    mock_redis_dao.get.return_value = CACHED_JSON
+
+    # Act
+    result = await query_service.find_by_playlist_id(playlist_id=PLAYLIST_ID)
+
+    # Assert
+    assert isinstance(result, PlaylistDto)
+    assert result.playlist_info.playlist_id == PLAYLIST_ID
+    assert len(result.items) == 1
+    mock_redis_dao.get.assert_called_once_with(key=f"playlist:{PLAYLIST_ID}")
+
+
+async def test_find_by_playlist_id_returns_none_on_cache_miss(query_service, mock_redis_dao):
+    """正常系: キャッシュミス時にNoneを返す"""
+    # Arrange
+    mock_redis_dao.get.return_value = None
+
+    # Act
+    result = await query_service.find_by_playlist_id(playlist_id=PLAYLIST_ID)
+
+    # Assert
+    assert result is None
+
+
+async def test_find_by_playlist_id_returns_none_on_invalid_json(query_service, mock_redis_dao):
+    """正常系: JSON破損時にNoneを返す"""
+    # Arrange
+    mock_redis_dao.get.return_value = "invalid json"
+
+    # Act
+    result = await query_service.find_by_playlist_id(playlist_id=PLAYLIST_ID)
+
+    # Assert
+    assert result is None
+
+
+async def test_find_by_playlist_id_returns_none_on_redis_error(query_service, mock_redis_dao):
+    """正常系: Redisエラー時にNoneを返す"""
+    # Arrange
+    mock_redis_dao.get.side_effect = Exception("Redis connection failed")
+
+    # Act
+    result = await query_service.find_by_playlist_id(playlist_id=PLAYLIST_ID)
+
+    # Assert
+    assert result is None
+
+
+async def test_find_by_playlist_id_returns_none_on_invalid_playlist_id(
+    query_service, mock_redis_dao
+):
+    """正常系: 不正なプレイリストIDではRedisを参照せずNoneを返す"""
+    # Act
+    result = await query_service.find_by_playlist_id(playlist_id="invalid id!")
+
+    # Assert
+    assert result is None
+    mock_redis_dao.get.assert_not_called()

--- a/tests/unit/infrastructure/query_service/test_playlist_query_service.py
+++ b/tests/unit/infrastructure/query_service/test_playlist_query_service.py
@@ -1,0 +1,265 @@
+"""
+PlaylistQueryService ユニットテスト
+
+PlaylistQueryServiceの正常系と異常系のテストを提供します。
+yt-dlpをモック化してテストします。
+"""
+
+from unittest.mock import patch
+
+import pytest
+import yt_dlp
+
+from streamshuttle.infrastructure.query_service.playlist_query_service import (
+    PlaylistQueryService,
+)
+from streamshuttle.shared.exceptions import (
+    InvalidUrlError,
+    PlaylistNotFoundError,
+    YouTubeResolverError,
+)
+
+PLAYLIST_URL = "https://www.youtube.com/playlist?list=PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf"
+
+
+@pytest.fixture
+def query_service():
+    """
+    PlaylistQueryServiceのフィクスチャ
+
+    Returns:
+        PlaylistQueryService: 取得上限3件のテスト用インスタンス
+    """
+    return PlaylistQueryService(max_items=3)
+
+
+def build_entry(video_id: str, title: str = "テスト動画", duration: float | None = 120.0) -> dict:
+    """
+    yt-dlpのフラット抽出エントリーを模したdictを生成します
+
+    Args:
+        video_id: 動画ID
+        title: 動画タイトル
+        duration: 動画の長さ（秒）
+
+    Returns:
+        dict: エントリー辞書
+    """
+    return {"id": video_id, "title": title, "duration": duration}
+
+
+async def test_playlist_query_service_returns_playlist_items(query_service):
+    """
+    正常系: プレイリスト情報と動画一覧が返されることを確認
+
+    Arrange: yt-dlpの_extract_infoをモックしてプレイリスト情報を返す
+    Act: get_playlist()を呼び出す
+    Assert: プレイリスト情報と動画一覧が返される
+    """
+    # Arrange
+    mock_info = {
+        "id": "PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf",
+        "title": "テストプレイリスト",
+        "uploader": "テストチャンネル",
+        "entries": [build_entry("dQw4w9WgXcQ", "1曲目"), build_entry("9bZkp7q19f0", "2曲目")],
+    }
+
+    # Act
+    with patch.object(query_service, "_extract_info", return_value=mock_info):
+        playlist_info, items = await query_service.get_playlist(PLAYLIST_URL)
+
+    # Assert
+    assert playlist_info.playlist_id == "PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf"
+    assert playlist_info.title == "テストプレイリスト"
+    assert playlist_info.uploader == "テストチャンネル"
+    assert playlist_info.item_count == 2
+    assert playlist_info.truncated is False
+    assert len(items) == 2
+    assert items[0].video_id == "dQw4w9WgXcQ"
+    assert items[0].title == "1曲目"
+    assert items[0].url == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    assert items[0].duration_seconds == 120
+    assert items[0].thumbnail_url == "https://i.ytimg.com/vi/dQw4w9WgXcQ/mqdefault.jpg"
+
+
+async def test_playlist_query_service_excludes_unplayable_entries(query_service):
+    """
+    正常系: 再生できないエントリーが一覧から除外されることを確認
+
+    Arrange: 非公開・削除済み・None・ID欠落のエントリーを含む情報を返す
+    Act: get_playlist()を呼び出す
+    Assert: 再生可能な動画のみが返される
+    """
+    # Arrange
+    mock_info = {
+        "id": "PLtest",
+        "title": "テストプレイリスト",
+        "entries": [
+            build_entry("dQw4w9WgXcQ", "再生できる動画"),
+            build_entry("9bZkp7q19f0", "[Private video]"),
+            build_entry("kJQP7kiw5Fk", "[Deleted video]"),
+            None,
+            {"title": "IDがないエントリー"},
+        ],
+    }
+
+    # Act
+    with patch.object(query_service, "_extract_info", return_value=mock_info):
+        playlist_info, items = await query_service.get_playlist(PLAYLIST_URL)
+
+    # Assert
+    assert len(items) == 1
+    assert items[0].video_id == "dQw4w9WgXcQ"
+    assert playlist_info.item_count == 1
+
+
+async def test_playlist_query_service_truncates_when_over_max_items(query_service):
+    """
+    正常系: 上限を超えるプレイリストが切り捨てられることを確認
+
+    Arrange: 上限（3件）を超える4件のエントリーを返す
+    Act: get_playlist()を呼び出す
+    Assert: 3件に切り詰められ、truncatedがTrueになる
+    """
+    # Arrange
+    mock_info = {
+        "id": "PLtest",
+        "title": "長いプレイリスト",
+        "entries": [build_entry(f"video{index:06d}") for index in range(4)],
+    }
+
+    # Act
+    with patch.object(query_service, "_extract_info", return_value=mock_info):
+        playlist_info, items = await query_service.get_playlist(PLAYLIST_URL)
+
+    # Assert
+    assert len(items) == 3
+    assert playlist_info.item_count == 3
+    assert playlist_info.truncated is True
+
+
+async def test_playlist_query_service_handles_missing_duration(query_service):
+    """
+    正常系: 長さが取得できない動画でもDTOが生成されることを確認
+
+    Arrange: durationがないエントリーを返す
+    Act: get_playlist()を呼び出す
+    Assert: duration_secondsがNoneになる
+    """
+    # Arrange
+    mock_info = {
+        "id": "PLtest",
+        "title": "テストプレイリスト",
+        "entries": [build_entry("dQw4w9WgXcQ", "ライブ配信", duration=None)],
+    }
+
+    # Act
+    with patch.object(query_service, "_extract_info", return_value=mock_info):
+        _, items = await query_service.get_playlist(PLAYLIST_URL)
+
+    # Assert
+    assert items[0].duration_seconds is None
+
+
+@pytest.mark.parametrize(
+    "mock_info",
+    [
+        pytest.param(None, id="異常系: 情報が取得できない"),
+        pytest.param({"id": "PLtest", "entries": []}, id="異常系: 動画が0件"),
+    ],
+)
+async def test_playlist_query_service_raises_when_playlist_is_empty(query_service, mock_info):
+    """
+    異常系: プレイリストが空の場合にPlaylistNotFoundErrorが送出されることを確認
+
+    Arrange: 空のプレイリスト情報を返す
+    Act: get_playlist()を呼び出す
+    Assert: PlaylistNotFoundErrorが送出される
+    """
+    # Act & Assert
+    with patch.object(query_service, "_extract_info", return_value=mock_info):
+        with pytest.raises(PlaylistNotFoundError):
+            await query_service.get_playlist(PLAYLIST_URL)
+
+
+async def test_playlist_query_service_raises_when_no_playable_entries(query_service):
+    """
+    異常系: 再生可能な動画が1件もない場合にPlaylistNotFoundErrorが送出されることを確認
+
+    Arrange: 非公開動画のみを含むプレイリスト情報を返す
+    Act: get_playlist()を呼び出す
+    Assert: PlaylistNotFoundErrorが送出される
+    """
+    # Arrange
+    mock_info = {
+        "id": "PLtest",
+        "title": "非公開のみ",
+        "entries": [build_entry("dQw4w9WgXcQ", "[Private video]")],
+    }
+
+    # Act & Assert
+    with patch.object(query_service, "_extract_info", return_value=mock_info):
+        with pytest.raises(PlaylistNotFoundError):
+            await query_service.get_playlist(PLAYLIST_URL)
+
+
+async def test_playlist_query_service_raises_invalid_url_error(query_service):
+    """
+    異常系: 無効なURLでInvalidUrlErrorが送出されることを確認
+
+    Arrange: 許可されないドメインのURLを準備
+    Act: get_playlist()を呼び出す
+    Assert: InvalidUrlErrorが送出される
+    """
+    # Act & Assert
+    with pytest.raises(InvalidUrlError):
+        await query_service.get_playlist("https://example.com/playlist?list=PLtest")
+
+
+async def test_playlist_query_service_raises_resolver_error_on_download_error(query_service):
+    """
+    異常系: 通信障害等のDownloadErrorがYouTubeResolverErrorに変換されることを確認
+
+    Arrange: _extract_infoが通信エラーのDownloadErrorを送出するようにモック
+    Act: get_playlist()を呼び出す
+    Assert: YouTubeResolverErrorが送出される
+    """
+    # Act & Assert
+    with patch.object(
+        query_service,
+        "_extract_info",
+        side_effect=yt_dlp.utils.DownloadError("Unable to download API page: timed out"),
+    ):
+        with pytest.raises(YouTubeResolverError):
+            await query_service.get_playlist(PLAYLIST_URL)
+
+
+@pytest.mark.parametrize(
+    "error_message",
+    [
+        pytest.param("The playlist does not exist.", id="異常系: 存在しないプレイリスト"),
+        pytest.param("This playlist is private", id="異常系: 非公開プレイリスト"),
+        pytest.param("Playlist not found", id="異常系: プレイリスト未検出"),
+    ],
+)
+async def test_playlist_query_service_raises_not_found_on_unavailable_playlist(
+    query_service, error_message
+):
+    """
+    異常系: プレイリスト自体が利用できない場合にPlaylistNotFoundErrorが送出されることを確認
+
+    通信障害（502相当）と、存在しない・非公開のプレイリスト（404相当）を
+    区別できることを検証します。
+
+    Arrange: _extract_infoが不存在・非公開を示すDownloadErrorを送出するようにモック
+    Act: get_playlist()を呼び出す
+    Assert: PlaylistNotFoundErrorが送出される
+    """
+    # Act & Assert
+    with patch.object(
+        query_service,
+        "_extract_info",
+        side_effect=yt_dlp.utils.DownloadError(error_message),
+    ):
+        with pytest.raises(PlaylistNotFoundError):
+            await query_service.get_playlist(PLAYLIST_URL)

--- a/tests/unit/infrastructure/repository/test_playlist_repository.py
+++ b/tests/unit/infrastructure/repository/test_playlist_repository.py
@@ -1,0 +1,78 @@
+"""PlaylistRepositoryのテストモジュール"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from streamshuttle.infrastructure.repository.playlist_repository import PlaylistRepository
+from streamshuttle.usecase.dto.playlist_dto import PlaylistDto
+from streamshuttle.usecase.dto.playlist_info_dto import PlaylistInfoDto
+from streamshuttle.usecase.dto.playlist_item_dto import PlaylistItemDto
+
+PLAYLIST_ID = "PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf"
+
+
+@pytest.fixture
+def mock_redis_dao():
+    """RedisDao のモックを提供するfixture"""
+    return AsyncMock()
+
+
+@pytest.fixture
+def repository(mock_redis_dao):
+    """PlaylistRepository のインスタンスを提供するfixture"""
+    return PlaylistRepository(redis_dao=mock_redis_dao)
+
+
+@pytest.fixture
+def playlist():
+    """保存対象のPlaylistDtoを提供するfixture"""
+    return PlaylistDto(
+        playlist_info=PlaylistInfoDto(
+            playlist_id=PLAYLIST_ID,
+            title="テストプレイリスト",
+            uploader="テストチャンネル",
+            item_count=1,
+            truncated=False,
+        ),
+        items=[
+            PlaylistItemDto(
+                video_id="dQw4w9WgXcQ",
+                title="1曲目",
+                url="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+                duration_seconds=120,
+                thumbnail_url="https://i.ytimg.com/vi/dQw4w9WgXcQ/mqdefault.jpg",
+            )
+        ],
+    )
+
+
+async def test_save_caches_playlist(repository, mock_redis_dao, playlist):
+    """正常系: save()がプレイリスト情報をキャッシュに保存する"""
+    # Act
+    await repository.save(playlist_id=PLAYLIST_ID, playlist=playlist)
+
+    # Assert
+    mock_redis_dao.set.assert_called_once()
+    call_args = mock_redis_dao.set.call_args
+    assert call_args.kwargs["key"] == f"playlist:{PLAYLIST_ID}"
+    assert "dQw4w9WgXcQ" in call_args.kwargs["value"]
+    assert call_args.kwargs["ttl"] > 0
+
+
+async def test_save_does_not_raise_on_redis_error(repository, mock_redis_dao, playlist):
+    """正常系: Redisエラー時でも例外を投げない（ベストエフォート）"""
+    # Arrange
+    mock_redis_dao.set.side_effect = Exception("Redis connection failed")
+
+    # Act & Assert（例外が投げられないことを確認）
+    await repository.save(playlist_id=PLAYLIST_ID, playlist=playlist)
+
+
+async def test_save_does_not_raise_on_invalid_playlist_id(repository, mock_redis_dao, playlist):
+    """正常系: 不正なプレイリストIDでも例外を投げず、保存を行わない"""
+    # Act & Assert（例外が投げられないことを確認）
+    await repository.save(playlist_id="invalid id!", playlist=playlist)
+
+    # Assert
+    mock_redis_dao.set.assert_not_called()

--- a/tests/unit/usecase/query/test_get_playlist_usecase.py
+++ b/tests/unit/usecase/query/test_get_playlist_usecase.py
@@ -1,0 +1,137 @@
+"""
+GetPlaylistUseCase ユニットテスト
+
+キャッシュヒット/ミス時の動作と、URLの正規化を検証します。
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from streamshuttle.shared.exceptions import InvalidPlaylistIdError, InvalidUrlError
+from streamshuttle.usecase.dto.playlist_dto import PlaylistDto
+from streamshuttle.usecase.dto.playlist_info_dto import PlaylistInfoDto
+from streamshuttle.usecase.dto.playlist_item_dto import PlaylistItemDto
+from streamshuttle.usecase.query.get_playlist_usecase import GetPlaylistUseCase
+
+PLAYLIST_ID = "PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf"
+PLAYLIST_URL = f"https://www.youtube.com/playlist?list={PLAYLIST_ID}"
+
+
+@pytest.fixture
+def playlist_info():
+    """プレイリスト情報のfixture"""
+    return PlaylistInfoDto(
+        playlist_id=PLAYLIST_ID,
+        title="テストプレイリスト",
+        uploader="テストチャンネル",
+        item_count=1,
+        truncated=False,
+    )
+
+
+@pytest.fixture
+def items():
+    """動画一覧のfixture"""
+    return [
+        PlaylistItemDto(
+            video_id="dQw4w9WgXcQ",
+            title="1曲目",
+            url="https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            duration_seconds=120,
+            thumbnail_url="https://i.ytimg.com/vi/dQw4w9WgXcQ/mqdefault.jpg",
+        )
+    ]
+
+
+@pytest.fixture
+def mock_query_service(playlist_info, items):
+    """PlaylistQueryServiceのモック"""
+    query_service = AsyncMock()
+    query_service.get_playlist.return_value = (playlist_info, items)
+    return query_service
+
+
+@pytest.fixture
+def mock_repository():
+    """PlaylistRepositoryのモック"""
+    return AsyncMock()
+
+
+@pytest.fixture
+def mock_cache_query_service():
+    """PlaylistCacheQueryServiceのモック（デフォルトはキャッシュミス）"""
+    cache_query_service = AsyncMock()
+    cache_query_service.find_by_playlist_id.return_value = None
+    return cache_query_service
+
+
+@pytest.fixture
+def use_case(mock_query_service, mock_repository, mock_cache_query_service):
+    """GetPlaylistUseCaseのfixture"""
+    return GetPlaylistUseCase(
+        query_service=mock_query_service,
+        repository=mock_repository,
+        cache_query_service=mock_cache_query_service,
+    )
+
+
+async def test_execute_fetches_and_caches_on_cache_miss(
+    use_case, mock_query_service, mock_repository, mock_cache_query_service, items
+):
+    """正常系: キャッシュミス時にyt-dlpで取得し、キャッシュに保存する"""
+    # Act
+    result_info, result_items = await use_case.execute(PLAYLIST_URL)
+
+    # Assert
+    mock_cache_query_service.find_by_playlist_id.assert_called_once_with(PLAYLIST_ID)
+    mock_query_service.get_playlist.assert_called_once_with(PLAYLIST_URL)
+    mock_repository.save.assert_called_once()
+    assert mock_repository.save.call_args.kwargs["playlist_id"] == PLAYLIST_ID
+    assert result_info.playlist_id == PLAYLIST_ID
+    assert result_items == items
+
+
+async def test_execute_returns_cached_playlist_on_cache_hit(
+    use_case, mock_query_service, mock_repository, mock_cache_query_service, playlist_info, items
+):
+    """正常系: キャッシュヒット時はyt-dlpを呼び出さない"""
+    # Arrange
+    mock_cache_query_service.find_by_playlist_id.return_value = PlaylistDto(
+        playlist_info=playlist_info, items=items
+    )
+
+    # Act
+    result_info, result_items = await use_case.execute(PLAYLIST_URL)
+
+    # Assert
+    mock_query_service.get_playlist.assert_not_called()
+    mock_repository.save.assert_not_called()
+    assert result_info == playlist_info
+    assert result_items == items
+
+
+async def test_execute_normalizes_watch_url_before_fetching(use_case, mock_query_service):
+    """正常系: listパラメータ付きwatch URLがプレイリスト取得用URLに正規化される"""
+    # Arrange
+    watch_url = f"https://www.youtube.com/watch?v=dQw4w9WgXcQ&list={PLAYLIST_ID}"
+
+    # Act
+    await use_case.execute(watch_url)
+
+    # Assert
+    mock_query_service.get_playlist.assert_called_once_with(PLAYLIST_URL)
+
+
+async def test_execute_raises_invalid_url_error(use_case):
+    """異常系: 許可されないドメインのURLでInvalidUrlErrorが送出される"""
+    # Act & Assert
+    with pytest.raises(InvalidUrlError):
+        await use_case.execute("https://example.com/playlist?list=PLtest")
+
+
+async def test_execute_raises_invalid_playlist_id_error(use_case):
+    """異常系: listパラメータがないURLでInvalidPlaylistIdErrorが送出される"""
+    # Act & Assert
+    with pytest.raises(InvalidPlaylistIdError):
+        await use_case.execute("https://www.youtube.com/watch?v=dQw4w9WgXcQ")


### PR DESCRIPTION
## 概要

YouTubeの公開プレイリストのURLを渡すと、含まれる動画を順番に再生できるプレイヤーを追加しました。

`https://www.youtube.com/playlist?list=...` を入力すると動画一覧が表示され、上から順に連続再生されます。`watch?v=...&list=...` 形式のURLもプレイリストとして解釈します。

## 追加したエンドポイント

| エンドポイント | 内容 | レート制限 |
| --- | --- | --- |
| `GET /player` | プレイヤーページ（HTML） | - |
| `GET /playlist?url=` | プレイリストの動画一覧を取得（JSON） | 5/分 |
| `GET /playlist/stream?video_id=` | 再生対象動画のストリームURLを解決（JSON） | 30/分 |

## 実装のポイント

**ストリームURLをリダイレクトではなくJSONで返す**
``'&lt;video src="/resolve?..."&gt;'`` のように307リダイレクトを挟むと、シークのたびにレンジリクエストが本サービスを経由し、レート制限を消費してしまいます。プレイヤーは曲ごとに1回だけURLを解決し、解決済みURLを直接 `<video>` に設定します。

**プレイリスト取得はフラット抽出 + キャッシュ**
yt-dlpの `extract_flat` で各動画のフォーマット解決を行わずID・タイトル・長さのみを取得し、結果はRedisにキャッシュします（TTLは既存の `CACHE_TTL_SECONDS`）。

**エラーの区別**
プレイリスト自体の不存在・非公開は404、通信障害などサービス側起因のエラーは502として返します。プレイリスト内の非公開・削除済み動画は再生できないため一覧から除外します。

**上限**
1プレイリストあたりの取得件数は `SECURITY_MAX_PLAYLIST_ITEMS`（デフォルト200件）で制限し、超過分は切り捨てたうえでUIに通知します。非公開プレイリスト（`WL` / `LL`）はValueObjectの時点で拒否します。

## プレイヤーの機能

- 連続再生（再生終了で自動的に次の動画へ）
- 前へ / 次へ、一覧クリックでの頭出し
- シャッフル、繰り返し
- 再生に失敗した動画は自動スキップ（全件失敗時は停止）

## 構成

既存のDDD 4層構造に沿って追加しています。

- Domain: `YoutubePlaylistUrl` / `YouTubePlaylistId` / `PlaylistCacheKey`
- UseCase: `GetPlaylistUseCase`、`PlaylistQueryService` / `PlaylistCacheQueryService` / `PlaylistRepository` の各インターフェースとDTO
- Infrastructure: yt-dlp実装、Redisキャッシュ実装
- Handler: `playlist_handler.py`
- Template/Static: `player.html` / `player.js` / CSS

ストリーム再生のためCSPに `media-src 'self' https://*.googlevideo.com` を追加し、ページごとに必要なスクリプトのみ読み込むよう `base.html` に `scripts` ブロックを追加しています（`/` は `app.js`、`/player` は `player.js`）。

## テスト

- ユニット・統合テスト計469件がパス（新規74件）
- `ruff check` / `ruff format --check` パス
- サーバーを起動し `/`・`/player`・静的ファイル・エラー系レスポンス・CSPヘッダーを確認

なお、この作業環境からはYouTubeへの通信が遮断されているため、実際のプレイリストを使った再生確認は行えていません。yt-dlp呼び出し部分はモックによるテストのみです。

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3rSP69HehnfkxJP2Zwugx)_